### PR TITLE
Sync display fixes and GM discipline improvements from claude-dnd-skill

### DIFF
--- a/SKILL-commands.md
+++ b/SKILL-commands.md
@@ -31,7 +31,7 @@ Do NOT run `git init` or any git commands in campaign directories. Do NOT create
 7. **Three Truths** — one settlement, one nearby threat, one mystery with a clue trail. Write to respective sections in world.md.
 8. **Threat Escalation Arc** — fill the five-stage table in world.md. Set current stage to 1. Write `Threat arc stage: 1` to `state.md → ## World State`.
 9. **2 Factions** — archetype, current activity, relationship to party. Write to `## Factions` in world.md and one-line summaries to `state.md → ## World State`.
-10. **3 NPCs with relationship web** — full entries: role, demeanor, motivation, secret, speech quirk, faction, current goal. Every NPC needs at least 2 relationships to others. Append to npcs.md.
+10. **3 NPCs with relationship web** — write a one-line index entry for each (name, role, demeanor, faction, current goal) to `npcs.md`. Write each NPC's full detail (personality axes, speech quirk, hidden motivation, secret, relationships) as a `## [Name]` section in `npcs-full.md`. Create that file if it does not exist. Every NPC needs at least 2 relationships to others.
 11. **3-5 Quest Seeds** from threat, factions, mystery, NPC motivations. Write to `## Quest Seed Bank` in world.md.
 12. Write state.md: session count 0, starting location, system, `_display_running` flag.
 13. Confirm creation. Offer `/gm character new`.
@@ -45,7 +45,7 @@ Do NOT run `git init` or any git commands in campaign directories. Do NOT create
    - Yes → `bash <skill-base>/display/start-display.sh`; set `_display_running = true`
    - No → continue
 3. Read `SKILL-scripts.md` (for script syntax this session)
-4. Read `state.md`, `world.md`, `npcs.md`, and all `characters/*.md` in the campaign directory.
+4. Read `state.md`, `world.md`, `npcs.md` (and `npcs-full.md` if present), and all `characters/*.md` in the campaign directory. Note: `session-log.md` is NOT loaded at session start — recent events are already in `state.md → ## Recent Events`.
 5. Load the system module: read `systems/<system>/system.md` (system is recorded in state.md).
 6. If display is running, push full party stats to the sidebar. Also push `--factions` from active faction states in `state.md → ## World State` (use `[]` if none), and `--quests` from active quests and open threads (use `[]` if none). Push turn order if combat was active. Quest status values: `active`, `threat`, `resolved`, `failed`.
 7. Deliver one in-character paragraph recapping the current situation — where the party is, what is at stake, what was last happening.
@@ -76,8 +76,9 @@ Keep only the 2 most recent full entries in session-log.md. Older entries move t
 
 1. Run `/gm save`, then:
    a. Append a Session Recap block to session-log.md with key events and open threads.
-   b. Ask: *"Quick calibration — what worked this session, and what would you adjust?"* Write to `### DM Calibration`. Skip if no answer.
+   b. Ask: *"Quick calibration — what worked this session, and what would you adjust?"* Write to `### GM Calibration`. Skip if no answer.
    c. Update `## World State` in state.md: check threat arc stage, faction states, in-world date.
+   d. If the calibration answer or session revealed a new, durable pattern about this player's preferences — update `## GM Style Notes` in state.md. Add one or two distilled principles. Do not recap the session; record the insight. Skip if nothing genuinely new emerged.
 2. If `_display_running = true`, stop the display:
    ```bash
    kill $(cat <skill-base>/display/app.pid 2>/dev/null) 2>/dev/null && rm -f <skill-base>/display/app.pid

--- a/SKILL.md
+++ b/SKILL.md
@@ -45,7 +45,9 @@ The player will tolerate failure, hard choices, and even character death if they
 Your excitement about the world is contagious. A GM who is clearly engaged — who relishes an NPC's voice, who finds the player's choices genuinely interesting, who is visibly delighted when something unexpected happens — gives the player permission to invest fully. Don't phone it in. If a scene doesn't interest you, find the angle that does.
 
 ### 9. Read This Specific Player
-The meta-skill beneath all of the above is knowing who is sitting across from you. A GM who is excellent for one player may be wrong for another. Pay attention to what *this* player responds to — their character choices, their questions, the moments they push back — and calibrate everything to them. This skill compounds over sessions; use `session-log.md` to track what worked and what didn't.
+The meta-skill beneath all of the above is knowing who is sitting across from you. A GM who is excellent for one player may be wrong for another. Pay attention to what *this* player responds to — their character choices, their questions, the moments they push back — and calibrate everything to them. This skill compounds over sessions.
+
+**How to compound it:** `state.md` contains a `## GM Style Notes` section — distilled, durable calibration principles for this specific player. Read it at every `/gm load`. Update it at `/gm end` only when a genuinely new pattern emerges (not a recap — an insight). This section survives session archival and carries your accumulated read of this player forward indefinitely.
 
 Ask leading questions to build investment. During quiet moments or at the start of a session, ask the player one specific question about their character: a relationship, a past event, an opinion about someone in the current scene. Their answer is a plot hook. Record answers that matter in the character file.
 
@@ -117,6 +119,25 @@ Once a campaign is loaded, stay in GM mode. Interpret all player messages as in-
 
 **Player input queue (display companion):**
 At the start of each turn, run `check_input.py` before processing the player's message. If it prints output, use those queued actions as part of (or all of) the player's action this turn. Empty output means no queued input — proceed normally.
+
+**Autorun mode** (`autorun: true` in `state.md → ## Session Flags`):
+
+When autorun is active, Claude drives the turn loop — no GM Enter required. After completing each response, run this blocking wait as the very last Bash call:
+
+```bash
+# Autorun wait — Ctrl+C to return to manual mode
+AUTORUN=$(bash <skill-base>/display/autorun-wait.sh)
+echo "$AUTORUN"
+```
+
+- If `AUTORUN` is non-empty: treat it as the player action for the next turn. Process immediately.
+- If `AUTORUN` is empty (timeout after 9 min): silently restart the wait — do not print anything.
+- If the GM sends a message mid-wait: the Bash is interrupted. Before processing the GM's message, run `check_input.py` once. If it returns content, that is queued player input that arrived during the gap — treat it as part of this turn alongside the GM's message. After resolving the turn, restart the wait if `autorun: true` is still in state.md.
+
+Do NOT run the autorun wait during individual combat turns, while a roll is pending a response, or when the GM has explicitly sent a message this turn.
+
+**NPC detail discipline:**
+Before writing substantive dialogue, decisions, or reactions for any named NPC, read their `## [Name]` section in `npcs-full.md` if that file exists. The index row in `npcs.md` carries surface traits only — personality axes, relationships, hidden goals, and speech quirks live in `npcs-full.md` and will drift without it. Do this proactively when a scene centres on that NPC, not only on explicit `/gm npc` commands.
 
 **Dice convention:**
 - Roll initiative automatically via `combat.py init` for all combatants at combat start

--- a/display/app.py
+++ b/display/app.py
@@ -153,11 +153,43 @@ _denied_devices:   set[str]       = set()
 _pending_devices:  dict[str, dict] = {}  # device_id -> {ip, first_seen}
 _devices_lock = threading.Lock()
 
+DEVICES_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), ".approved_devices.json")
+
+
+def _load_approved_devices() -> None:
+    """Load persisted approved device IDs from disk at startup."""
+    global _approved_devices
+    try:
+        with open(DEVICES_FILE) as f:
+            ids = json.load(f)
+        if isinstance(ids, list):
+            with _devices_lock:
+                _approved_devices = set(ids)
+    except FileNotFoundError:
+        pass
+    except Exception as e:
+        print(f"[display] warning: could not load approved devices: {e}", file=sys.stderr)
+
+
+def _persist_approved_devices() -> None:
+    """Write approved device IDs to disk. Must be called WITHOUT _devices_lock held."""
+    with _devices_lock:
+        ids = list(_approved_devices)
+    try:
+        with open(DEVICES_FILE, "w") as f:
+            json.dump(ids, f)
+    except Exception as e:
+        print(f"[display] warning: could not persist approved devices: {e}", file=sys.stderr)
+
+
+_load_approved_devices()
+
 
 def _device_ok(device_id: str, ip: str) -> str:
     """Return 'approved', 'pending', or 'denied' for a given device."""
     if not device_id:
         return "denied"
+    _need_persist = False
     with _devices_lock:
         if device_id in _approved_devices:
             return "approved"
@@ -166,16 +198,19 @@ def _device_ok(device_id: str, ip: str) -> str:
         # Localhost always auto-approved
         if ip in ("127.0.0.1", "::1"):
             _approved_devices.add(device_id)
-            return "approved"
-        # New LAN device — hold and notify DM
-        if device_id not in _pending_devices:
+            _need_persist = True
+        elif device_id not in _pending_devices:
+            # New LAN device — hold and notify DM
             _pending_devices[device_id] = {
                 "id":         device_id,
                 "ip":         ip,
                 "first_seen": _time.time(),
             }
             _broadcast({"device_request": {"id": device_id, "ip": ip}})
-        return "pending"
+    if _need_persist:
+        _persist_approved_devices()
+        return "approved"
+    return "pending"
 
 
 # ─── Staged input system ──────────────────────────────────────────────────────
@@ -409,7 +444,6 @@ SCENES: dict[str, dict] = {
         "keywords": [
             "city", "market", "street", "crowd", "village", "town",
             "square", "cobble", "district", "quarter", "merchant",
-            "ashenveil",
         ],
         "colors": ["#0a0f1a", "#15202e"],
         "accent": "#6080a0",
@@ -1046,9 +1080,20 @@ def stats():
         if "world_time" in data:
             _current_stats["world_time"] = data["world_time"]
 
-        # factions replaces entirely ([] clears)
+        # factions replaces entirely ([] clears); validate and default missing standing
         if "factions" in data:
-            _current_stats["factions"] = data["factions"]
+            _VALID_STANDINGS = {"Allied", "Friendly", "Neutral", "Unfriendly", "Hostile"}
+            validated_factions = []
+            for _f in data["factions"]:
+                if "standing" not in _f or _f["standing"] not in _VALID_STANDINGS:
+                    print(
+                        f"[display] faction '{_f.get('name','?')}' missing/invalid standing "
+                        f"— defaulting to Neutral. Valid: {sorted(_VALID_STANDINGS)}",
+                        file=sys.stderr,
+                    )
+                    _f = dict(_f, standing="Neutral")
+                validated_factions.append(_f)
+            _current_stats["factions"] = validated_factions
 
         # quests replaces entirely ([] clears)
         if "quests" in data:

--- a/display/templates/index.html
+++ b/display/templates/index.html
@@ -2814,7 +2814,7 @@ let _openSheetName = null;
 function openSheet(name) {
   _openSheetName = name;
   const p = _playerData[name];
-  if (!p) return;
+  if (!p) { console.warn('[sheet] player not found:', name, '— available:', Object.keys(_playerData)); return; }
   const content = document.getElementById('sheet-content');
   content.innerHTML = '';
 
@@ -3045,7 +3045,7 @@ function openSheet(name) {
     content.appendChild(_smDivider());
     const noData = document.createElement('div');
     noData.className = 'sm-no-data';
-    noData.textContent = 'Full sheet not loaded — include "sheet" in the player object when pushing stats on /dnd load';
+    noData.textContent = 'Full sheet not loaded — run /gm load to restore.';
     content.appendChild(noData);
   }
 

--- a/templates/state.md
+++ b/templates/state.md
@@ -33,4 +33,8 @@
 ## Session Flags
 *(tutor_mode, etc. — session-scoped flags set via /dnd commands)*
 
-## DM Notes (hidden from players)
+## GM Style Notes
+*Distilled calibration for this specific player — read at every /gm load, updated at /gm end only when a genuinely new pattern emerges.*
+*(none yet)*
+
+## GM Notes (hidden from players)


### PR DESCRIPTION
## Summary

Ports 8 improvements from [claude-dnd-skill](https://github.com/Bobby-Gray/claude-dnd-skill) identified during active campaign gameplay. Each change was evaluated against open-tabletop-gm's constraints (LLM-agnostic, game-system-agnostic, Python-first, no absolute paths) before being adapted for this repo. None of these are direct copies — implementations differ in naming, path conventions, and scope.

4 items were intentionally skipped: Inspiration award/spend (D&D-specific mechanic; no system-agnostic equivalent yet), XP feed blocks (same reason — deferred to a future generic `--milestone` event), session tail buffer (already solved by the existing `_text_log` persistence), and features format (already correct in this repo).

---

## `display/app.py`

**Faction standings validation** — the `/stats` handler silently accepted faction objects with missing or invalid `standing` values, causing the sidebar to render `—` with no indication of why. Added validation that defaults any missing/invalid standing to `"Neutral"` and logs a stderr warning with the valid values listed. Root cause: the LLM occasionally omits the field when constructing faction JSON from campaign prose.

**Device approval persistence** — `_approved_devices` was an in-memory set only. Any display restart (crash or intentional) silently reset all approvals; LAN player devices returned to "pending" with no notification. Approvals are now written to `.approved_devices.json` (alongside the existing `.token` file) and loaded at startup. Restart no longer disrupts connected players.

**Deadlock fix in `_device_ok()`** — the localhost auto-approve path added a device to `_approved_devices` and then called `_persist_approved_devices()` while still holding `_devices_lock`. `threading.Lock` is not reentrant in Python. This deadlocked every Flask worker thread touching `/stream` — the display loaded blank with no SSE connection established. Fixed with a `_need_persist` flag: set the flag inside the lock, call persist after release. `_persist_approved_devices()` is now documented as requiring the lock to be released before calling.

**Removed campaign-specific keyword** — `"ashenveil"` (a city name from an active test campaign) had been added to the city scene keyword list. Removed to keep the scene definitions generic.

---

## `display/templates/index.html`

**Sheet modal: debug warning on missing player** — `openSheet()` silently returned when the given name didn't match any key in `_playerData` (case-exact lookup). Without any feedback, this looked like a broken modal rather than a name mismatch. Added `console.warn` that logs the name that was requested alongside all available player names.

**Sheet modal: system-agnostic no-data hint** — the empty-sheet fallback message read `"include 'sheet' in the player object when pushing stats on /dnd load"` — referencing the D&D-specific `/dnd load` command. Updated to `/gm load` to match this repo's command namespace.

---

## `SKILL.md`

**Autorun mode documentation + mid-wait queue fix** — the `autorun-wait.sh` infrastructure existed but the wait loop and its failure mode were undocumented in SKILL.md. Added the full autorun section. The critical addition: when a GM message interrupts the blocking wait, any player input that arrived in `.input_queue` during the gap was previously discarded. The procedure now requires running `check_input.py` before processing the GM message; if it returns content, that queued input is treated as part of the current turn.

**Standard 9 — GM Style Notes** — Standard 9 ("Read This Specific Player") previously referenced `session-log.md` as the calibration mechanism. Session logs get archived after a few sessions, so calibration notes accumulated there were eventually lost. Updated to reference `state.md → ## GM Style Notes` — a dedicated section that survives archival and is read at every `/gm load`. The intent: player-specific calibration compounds across sessions rather than resetting.

**NPC full-entry discipline** — added explicit guidance to read a named NPC's `## [Name]` section in `npcs-full.md` proactively before writing substantive dialogue or decisions for them — not only when `/gm npc [name]` is called. The index row in `npcs.md` carries only surface traits; personality axes, hidden motivations, and speech quirks live in the full-entry file.

---

## `SKILL-commands.md`

**`/gm new` step 10 — NPC two-file split** — NPC creation previously wrote full entries directly to `npcs.md`. That conflates the index (for quick reference, always loaded) with full character detail (expensive to load, rarely needed all at once). Split into: one-line index entries → `npcs.md`; full detail (personality axes, speech quirk, hidden motivation, secret, relationships) → `## [Name]` sections in `npcs-full.md`. Mirrors the discipline documented in SKILL.md.

**`/gm load` step 4 — npcs-full.md and session-log.md** — extended the load step to read `npcs-full.md` if present, and explicitly documented that `session-log.md` is NOT loaded at session start (recent events are already in `state.md → ## Recent Events`). Previously this was ambiguous.

**`/gm end` step (d) — GM Style Notes update** — added a step to update `state.md → ## GM Style Notes` at session end when calibration feedback or session events reveal a new durable pattern about the player. Guidance: record the insight (not a recap), skip if nothing genuinely new emerged.

---

## `templates/state.md`

Added `## GM Style Notes` section to the blank campaign template. New campaigns created with `/gm new` will include this section from the start, ready to receive calibration notes after the first session.

---

## Test plan

- [ ] Push factions with a missing `standing` field — verify sidebar shows "Neutral" and stderr warning fires
- [ ] Push factions with valid `standing` values — verify no warning and correct sidebar colours
- [ ] Approve a LAN device, restart `app.py`, verify device does not need re-approval (`.approved_devices.json` persists)
- [ ] Confirm `/stream` connects immediately on localhost without deadlock
- [ ] Verify city scene keyword `ashenveil` is no longer present in `display/app.py`
- [ ] Call `openSheet()` with a name not in `_playerData` — verify `console.warn` fires with available names
- [ ] Push stats without `sheet` data — verify modal shows `/gm load` hint rather than `/dnd load`
- [ ] Enable autorun, submit player input via display panel, send a GM message mid-wait — verify queued input is not dropped
- [ ] Create a new campaign with `/gm new` — verify `npcs-full.md` is created alongside `npcs.md`, `## GM Style Notes` section present in `state.md`
- [ ] Load a campaign with an existing `npcs-full.md` — verify it is read as part of step 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)