### PR TITLE
Sync display fixes from claude-dnd-skill (path fix, per-campaign log, check_input)

### DIFF
--- a/SYSTEM-PORTING.md
+++ b/SYSTEM-PORTING.md
@@ -129,7 +129,7 @@ These scripts are D&D specific and live in `systems/dnd5e/`. You don't need to r
 | `ability-scores.py` | Generates D&D ability scores (roll arrays, point buy) | Build your own if character creation needs scripting |
 | `character.py` | D&D stat block calculation and level-up | Build your own for systems with different math |
 | `lookup.py` + `build_srd.py` + `sync_srd.py` | D&D 5e SRD dataset lookup | Build your own data layer if your system has open licensing; skip if proprietary |
-| `build_supplemental.py` | Fetches non-SRD D&D spells/features from wikidot | D&D specific — skip |
+| `build_supplemental.py` | Fetches non-SRD D&D spells/features from wikidot and caches to `systems/dnd5e/data/dnd5e_supplemental.json` | Already ported — run after `build_srd.py` to populate the supplemental dataset |
 
 For most systems, you can start without any system-specific scripts and rely entirely on `system.md` for rules context. Add scripts later when you identify specific calculations the GM gets wrong repeatedly.
 

--- a/display/app.py
+++ b/display/app.py
@@ -34,8 +34,11 @@ from typing import Optional
 from flask import Flask, Response, request, render_template, jsonify
 from flask_cors import CORS
 
-LOG_FILE      = os.path.expanduser("~/.claude/skills/dnd/display/text_log.json")
-SCRIPTS_DIR   = os.path.expanduser("~/.claude/skills/dnd/scripts")
+_DISPLAY_DIR  = os.path.dirname(os.path.abspath(__file__))
+_SKILL_DIR    = os.path.dirname(_DISPLAY_DIR)
+SCRIPTS_DIR   = os.path.join(_SKILL_DIR, "scripts")
+LOG_FILE      = os.path.join(_DISPLAY_DIR, "text_log.json")
+_LOG_FALLBACK = LOG_FILE
 
 # SRD lookup module — degrades silently if dataset not built
 if SCRIPTS_DIR not in sys.path:
@@ -48,22 +51,21 @@ except Exception:
     _SRD_AVAILABLE = False
 
 # Audio module — degrades silently if numpy not installed
-_AUDIO_DIR = os.path.dirname(os.path.abspath(__file__))
 import sys as _sys
-if _AUDIO_DIR not in _sys.path:
-    _sys.path.insert(0, _AUDIO_DIR)
+if _DISPLAY_DIR not in _sys.path:
+    _sys.path.insert(0, _DISPLAY_DIR)
 try:
     import audio as _audio
     _audio.init()
 except Exception:
     _audio = None   # type: ignore
-HELP_LOCK     = os.path.expanduser("~/.claude/skills/dnd/display/.help-lock")
-CAMP_FILE     = os.path.expanduser("~/.claude/skills/dnd/display/.campaign")
-STATS_FILE    = os.path.expanduser("~/.claude/skills/dnd/display/stats.json")
-TOKEN_FILE    = os.path.expanduser("~/.claude/skills/dnd/display/.token")
-INPUT_FILE    = os.path.expanduser("~/.claude/skills/dnd/display/player_input.json")
-TRIGGER_FILE  = os.path.expanduser("~/.claude/skills/dnd/display/.input_trigger")
-QUEUE_FILE    = os.path.expanduser("~/.claude/skills/dnd/display/.input_queue")
+HELP_LOCK     = os.path.join(_DISPLAY_DIR, ".help-lock")
+CAMP_FILE     = os.path.join(_DISPLAY_DIR, ".campaign")
+STATS_FILE    = os.path.join(_DISPLAY_DIR, "stats.json")
+TOKEN_FILE    = os.path.join(_DISPLAY_DIR, ".token")
+INPUT_FILE    = os.path.join(_DISPLAY_DIR, "player_input.json")
+TRIGGER_FILE  = os.path.join(_DISPLAY_DIR, ".input_trigger")
+QUEUE_FILE    = os.path.join(_DISPLAY_DIR, ".input_queue")
 
 # ─── LAN / TLS mode ───────────────────────────────────────────────────────────
 # Pass --lan to bind on 0.0.0.0 and protect write endpoints with a token.
@@ -717,9 +719,23 @@ _clients_lock = threading.Lock()
 
 # ─── Text replay log ──────────────────────────────────────────────────────────
 # Stores the last N cleaned text chunks so late-connecting browsers can catch up.
-# Persisted to LOG_FILE so it survives Flask restarts (Chromecast reconnects, new sessions).
+# Persisted per-campaign so switching campaigns loads the correct session tail.
+# Falls back to the display directory when no campaign is active.
 _text_log: deque = deque(maxlen=60)
 _text_log_lock = threading.Lock()
+
+
+def _get_log_file() -> str:
+    """Return the campaign-specific log path, or the fallback display-dir path."""
+    try:
+        camp = open(CAMP_FILE).read().strip()
+        if camp:
+            return os.path.expanduser(
+                f"~/open-tabletop-gm/campaigns/{camp}/text_log.json"
+            )
+    except Exception:
+        pass
+    return _LOG_FALLBACK
 
 
 def _persist_log() -> None:
@@ -727,17 +743,17 @@ def _persist_log() -> None:
     try:
         with _text_log_lock:
             data = list(_text_log)
-        with open(LOG_FILE, "w") as f:
+        with open(_get_log_file(), "w") as f:
             json.dump(data, f)
     except Exception:
         pass
 
 
 def _load_log() -> None:
-    """Load a previously persisted text log on startup.
+    """Load a previously persisted text log. Called at startup and on campaign switch.
     Handles both old string format and new dict format."""
     try:
-        with open(LOG_FILE) as f:
+        with open(_get_log_file()) as f:
             data = json.load(f)
         with _text_log_lock:
             _text_log.clear()
@@ -872,6 +888,17 @@ def chunk():
     if not _token_ok():
         return "Forbidden", 403
     data = request.get_json(silent=True) or {}
+
+    # Campaign registration — write .campaign file and reload log for correct per-campaign
+    # replay. Sent by send.py --set-campaign at /gm load. May arrive with or without text.
+    if "campaign" in data:
+        try:
+            with open(CAMP_FILE, "w") as f:
+                f.write(str(data["campaign"]).strip())
+            _load_log()
+        except Exception:
+            pass
+
     raw = data.get("text", "")
     if not raw:
         return "", 204

--- a/display/check_input.py
+++ b/display/check_input.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""
+check_input.py — Non-blocking check for queued player input.
+
+Drains the display companion's player input queue and prints any pending
+actions to stdout, then exits. If the queue is empty, exits silently.
+
+Primary path — HTTP drain endpoint (display running):
+  POSTs to /player-input/drain, which clears both the in-memory queue and
+  the persisted .input_queue file atomically. Follows send.py's token/scheme
+  pattern for auth and TLS.
+
+Fallback path — file read (display not running or unreachable):
+  Reads .input_queue directly and writes [] to clear it. Useful after a
+  display crash or when running without the companion.
+
+Output format (when non-empty):
+  [CharName]: action text
+  [CharName2]: action text
+
+One line per character. Called at the start of each GM turn:
+  python3 display/check_input.py
+"""
+import json
+import os
+import pathlib
+import ssl
+import sys
+import urllib.request
+
+_DIR         = pathlib.Path(__file__).parent
+_SCHEME_FILE = _DIR / ".scheme"
+_SCHEME      = _SCHEME_FILE.read_text().strip() if _SCHEME_FILE.exists() else "http"
+DRAIN_URL    = f"{_SCHEME}://localhost:5001/player-input/drain"
+TOKEN_FILE   = _DIR / ".token"
+QUEUE_FILE   = _DIR / ".input_queue"
+
+_SSL_CTX = None
+if _SCHEME == "https":
+    _SSL_CTX = ssl.create_default_context()
+    _SSL_CTX.check_hostname = False
+    _SSL_CTX.verify_mode    = ssl.CERT_NONE
+
+
+def _print_entries(entries: list) -> None:
+    for entry in entries:
+        char = entry.get("character", "Player")
+        text = entry.get("text", "").strip()
+        if text:
+            print(f"[{char}]: {text}")
+
+
+# Primary: HTTP drain — clears memory and file atomically
+try:
+    token = TOKEN_FILE.read_text().strip() if TOKEN_FILE.exists() else ""
+    req = urllib.request.Request(
+        DRAIN_URL, method="POST",
+        headers={"X-Token": token, "Content-Length": "0"},
+    )
+    with urllib.request.urlopen(req, context=_SSL_CTX, timeout=2) as resp:
+        entries = json.loads(resp.read())
+    _print_entries(entries)
+    sys.exit(0)
+except Exception:
+    pass
+
+# Fallback: read queue file directly (display not running or unreachable)
+try:
+    if QUEUE_FILE.exists():
+        entries = json.loads(QUEUE_FILE.read_text())
+        QUEUE_FILE.write_text("[]")   # clear without deleting — app sees empty queue on next persist
+        _print_entries(entries)
+except Exception:
+    pass

--- a/display/send.py
+++ b/display/send.py
@@ -271,15 +271,36 @@ def main() -> None:
         help="Start a timed effect: NAME:SPELL:DURATION (10r/60m/8h/indef) optionally :conc")
     parser.add_argument("--effect-end", action="append", metavar="NAME:SPELL",
         help="End a timed effect: NAME:SPELL (narrative end — broken, dispelled, player drops)")
+    parser.add_argument("--set-campaign", metavar="NAME",
+        help="Register the active campaign with the display server (call at /gm load)")
 
     args = parser.parse_args()
 
     text = sys.stdin.read()
     token = _read_token()
 
+    # ── Campaign registration ─────────────────────────────────────────────────
+    # Sent with or without narration text. The server writes .campaign and reloads
+    # the per-campaign text log so late-connecting browsers see the right session tail.
+    if args.set_campaign:
+        payload: dict = {"campaign": args.set_campaign}
+        if text.strip():
+            payload["text"] = text
+            # Attach any message-type flags
+            if args.action:
+                payload["action"] = args.action
+            elif args.player:
+                payload["player"] = args.player
+            elif args.npc:
+                payload["npc"] = args.npc
+            elif args.dice:
+                payload["dice"] = True
+            elif args.tutor:
+                payload["tutor"] = True
+        _post(FLASK_URL, json.dumps(payload).encode("utf-8"), token)
     # ── Text send ─────────────────────────────────────────────────────────────
-    if text.strip():
-        payload: dict = {"text": text}
+    elif text.strip():
+        payload = {"text": text}
         if args.action:
             payload["action"] = args.action
         elif args.player:

--- a/systems/dnd5e/data/.gitkeep
+++ b/systems/dnd5e/data/.gitkeep
@@ -1,2 +1,7 @@
-# SRD dataset
-Run: python3 systems/dnd5e/build_srd.py to generate dnd5e_srd.json
+# Generated data files (gitignored — run scripts to populate)
+#
+#   dnd5e_srd.json         — run: python3 systems/dnd5e/build_srd.py
+#   dnd5e_supplemental.json — run: python3 systems/dnd5e/build_supplemental.py
+#
+# Both files are excluded from version control. They may be large and contain
+# content under separate licensing terms. Generate them locally before use.


### PR DESCRIPTION
## Summary

- **Path leakage fix** — all `~/.claude/skills/dnd/` absolute paths in `app.py` replaced with `__file__`-relative constants (`_DISPLAY_DIR`, `_SKILL_DIR`); the file now works from any install location
- **Per-campaign text log routing** — `_get_log_file()` routes `text_log.json` to `~/open-tabletop-gm/campaigns/<name>/` on campaign switch; prevents session tails from different campaigns overwriting each other
- **Campaign registration** — new `--set-campaign NAME` flag in `send.py`; `/chunk` handler writes `.campaign` and reloads the log buffer; call at `/gm load` so the correct campaign tail is replayed for late-connecting displays
- **`check_input.py`** — new script; drains the player input queue at turn start (already referenced in `SKILL.md`); primary path is HTTP `/player-input/drain` (atomic, clears memory + file); degrades to file read if display is unreachable
- **`systems/dnd5e/build_supplemental.py`** — corrected in `SYSTEM-PORTING.md` from "skip" to "already ported"; `.gitkeep` updated to document both generated data files

## Skipped / deferred

- Easter-egg content from `dnd5e_supplemental.json` — left as claude-dnd-skill specific
- Arc system, `/gm import`, Live State Flags, state.md template — covered in the companion PR (PR 2)

## Test plan

- [ ] Start display with `--lan`, confirm paths resolve correctly relative to `display/`
- [ ] Run `/gm load` with `send.py --set-campaign <name>`, confirm `.campaign` is written and `text_log.json` appears in the campaign directory
- [ ] Submit a player action from companion UI, run `check_input.py` — confirm output; confirm HTTP drain clears the UI indicator
- [ ] Stop display, submit action (written to `.input_queue`), run `check_input.py` — confirm file fallback path returns the action
- [ ] Switch campaigns — confirm `_load_log()` switches to the new campaign's `text_log.json`