### PR TITLE
Sync arc system, campaign import, and Live State Flags from claude-dnd-skill

### DIFF
--- a/SKILL-commands.md
+++ b/SKILL-commands.md
@@ -32,6 +32,8 @@ Do NOT run `git init` or any git commands in campaign directories.
 | `/gm tutor on\|off` | Toggle tutor mode. Write `tutor_mode: true\|false` to state.md. |
 | `/gm display <on\|off> [--lan]` | Start or stop the display companion. Follow `/gm display` branch. Start before `/gm load` if you want it active. |
 | `/gm npc <name>` | Generate or retrieve an NPC. Write to npcs.md / npcs-full.md. |
+| `/gm import <filepath> [campaign-name]` | Import a pre-written campaign source (PDF, MD, DOCX, TXT). See `/gm import` procedure below. |
+| `/gm arc [status\|advance\|revise\|view]` | Manage the dynamic campaign arc. See `/gm arc` procedure below. |
 
 ---
 
@@ -49,10 +51,107 @@ Do NOT run `git init` or any git commands in campaign directories.
 11. **3 NPCs** — one-line index in npcs.md; full detail in npcs-full.md; each needs 2+ relationships
 12. **3-5 Quest Seeds** → write to `## Quest Seed Bank` in world.md
 13. Write state.md: session count 0, starting location, system, display flag
-14. Confirm creation. Offer `/gm character new`.
+14. **Dynamic Campaign Arc** — optional arc generation. Ask: *"Generate a committed narrative arc? [y/n — recommended]"*
+
+   **If yes:** Drawing from theme, threat arc stages, factions, Three Truths, NPC motivations, and quest seeds, derive:
+   - `theme` — one sentence: what this story is ultimately about (not what happens, but what it means)
+   - `resolution` — the committed endpoint shape: not specific events, but the emotional/thematic truth if the party succeeds
+   - Six beats across three acts (Inciting Incident, Complication, Midpoint Shift, All Is Lost, Final Confrontation, Resolution)
+   - For each beat: `label`, `what_changes` (consequence, not event), `world_pressure` (faction/NPC move that delivers it)
+
+   Write to `state.md → ## Campaign Arc` with `type: dynamic`. Deliver a one-paragraph arc summary. A capable model (Opus-class or equivalent) is recommended for this step — the quality of the arc depends on synthesising all world data into a coherent thematic shape.
+
+   **If no:** Write `type: sandbox` to `## Campaign Arc`. Story remains open-ended with no arc tracking.
+
+15. Confirm creation. Offer `/gm character new`.
 
 ---
 
-## `/gm save` — Session Log Archival
+## `/gm save` — Session Save Procedure
 
-After session count > 3: keep only 2 most recent full entries in session-log.md. Older entries move to `session-log-archive.md` (append only). Extract 3-5 bullet continuity summary into `## Continuity Archive` in state.md per archived session.
+1. **Update session-log.md** — append a new session entry with date, key events, NPC interactions, decisions, and consequences.
+2. **Increment session count** in state.md header. Update `last session` date.
+3. **Sync World State** — update `state.md → ## World State`: advance in-world date if time passed, update faction states if they shifted, advance the threat arc stage if events warrant it.
+4. **Update `## Live State Flags`** — review and update the compact key-value block: cover/party position, faction stances toward the party (non-neutral only), NPC dispositions (changed or notable only). This section must be accurate after every save — it is the compaction-resilience anchor for future sessions.
+5. **Arc check** (dynamic arcs only — skip for sandbox and structured):
+   - If `## Campaign Arc` has `type: dynamic`, review this session's key events against `outstanding_beats`.
+   - Ask: *"Did any arc beats land this session? [beat id(s) like '1b 2a', or 'none']"*
+   - If beats landed: run `/gm arc advance <beat-id>` for each. Update `steering_notes` for the next outstanding beat.
+6. **Session log archival** (after session count > 3): keep only the 2 most recent full entries in session-log.md. Move older entries to `session-log-archive.md` (append only, never delete). Before archiving each entry, extract a 3–5 bullet continuity summary and write it to `## Continuity Archive` in state.md.
+
+---
+
+## `/gm import <filepath> [campaign-name]`
+
+Import a pre-written campaign source and build a structured campaign from it.
+
+**Supported formats:** PDF, markdown (.md), DOCX, plain text (.txt)
+
+**Step 1 — Extract and assess the source:**
+```bash
+python3 scripts/import_campaign.py "<filepath>" --info
+python3 scripts/import_campaign.py "<filepath>" --chunks  # total chunks
+python3 scripts/import_campaign.py "<filepath>" --chunk 0  # read first chunk
+```
+For large sources (> 1 chunk), read subsequent chunks until you have enough to assess structure. You do not need to read every chunk before writing files — return to the source as needed.
+
+**Step 2 — Determine campaign name** (use `[campaign-name]` if provided, otherwise derive from source title).
+
+**Step 3 — Identify structure type:**
+- `linear` — scene-chain A→B→C (dungeon crawl, one-shot, heist)
+- `hub-and-spoke` — central hub + spoke locations in player-driven order (hexcrawl, published adventure module)
+- `faction-web` — multi-faction city/complex with overlapping arcs (political, intrigue)
+
+**Step 4 — Show a structured summary before writing any files:**
+```
+Source:   <title and author if present>
+Campaign: <proposed name>
+System:   <detected game system>
+Type:     structured / <structure type>
+Acts:     <N acts, N chapters>
+NPCs:     <N named characters identified>
+Factions: <N factions identified>
+```
+Confirm before proceeding.
+
+**Step 5 — Create campaign files** at `~/open-tabletop-gm/campaigns/<name>/`:
+
+- **world.md** — setting, geography, factions (with archetype, activity, goals), key locations, quest seeds
+- **npcs.md** — one-line index (name | role | one trait | status); full entries with voice, goals, relationships, secrets in **npcs-full.md**
+- **session-log.md** — Session 0 import record: source title, structure type, import date, summary of campaign premise
+- **state.md** — from template; populate:
+  - `## World State` — in-world start date if given, faction states, threat arc stage 1
+  - `## Campaign Arc` — full act/chapter structure with key beats, telegraph scenes, and steering notes (use `type: structured` format)
+  - `## Live State Flags` — empty at import, populated as sessions run
+
+**Step 6 — Deliver a one-paragraph campaign brief** covering premise, tone, opening situation, and how the first session should begin.
+
+---
+
+## `/gm arc [status|advance|revise|view]`
+
+Manage the dynamic campaign arc. Active only when `state.md → ## Campaign Arc` has `type: dynamic` — no-op for sandbox and structured campaigns.
+
+- **`/gm arc`** or **`/gm arc status`** — print current act, current beat label, `what_changes` for the current beat, and `steering_notes`. Quick reference, one screen.
+
+- **`/gm arc advance [beat-id]`** — mark the named beat complete (current beat if omitted). Remove from `outstanding_beats`. Advance `current_beat` to the next pending beat. If all beats in an act are complete, advance `current_act`. Update `steering_notes` to describe how to reach the newly current beat without forcing it.
+
+  **When the final beat (3b) is marked complete — arc continuation:**
+  `outstanding_beats` is now empty. Ask: *"The arc is complete. Continue the campaign with a new arc? [y/n]"*
+  - **Yes** → run `/gm arc new` (see below).
+  - **No** → mark campaign concluded. The arc stays in state.md as a record.
+
+- **`/gm arc revise`** — revise the arc when a player choice significantly redirects the story. Update outstanding beats to fit the new direction. Log the revision in `revision_log`. The committed `resolution` shape should bend to the story, not break — revise beats, not the endpoint.
+
+- **`/gm arc view`** — print the full arc yaml from state.md.
+
+- **`/gm arc new`** — generate a new arc for a campaign that has completed its previous arc. A capable model (Opus-class or equivalent) is recommended for this step.
+
+  The new arc must be **intentionally distinct** — not a continuation of the same conflict, but a new chapter that grows from the changed world. The resolution of arc N is the status quo of arc N+1.
+
+  1. Read the completed arc's `resolution` field — this is now the world's baseline.
+  2. Read `## World State` — faction shifts, threat changes, NPC status changes from the completed arc.
+  3. Generate a new arc from this evolved world state following the same six-beat structure.
+  4. Write it to `state.md → ## Campaign Arc` with `arc_number` incremented.
+  5. Move the completed arc to `## Arc History` (append, never delete).
+  6. Deliver a one-paragraph brief on the new arc's theme and opening pressure.

--- a/SKILL.md
+++ b/SKILL.md
@@ -139,6 +139,52 @@ Do NOT run the autorun wait during individual combat turns, while a roll is pend
 **NPC detail discipline:**
 Before writing substantive dialogue, decisions, or reactions for any named NPC, read their `## [Name]` section in `npcs-full.md` if that file exists. The index row in `npcs.md` carries surface traits only — personality axes, relationships, hidden goals, and speech quirks live in `npcs-full.md` and will drift without it. Do this proactively when a scene centres on that NPC, not only on explicit `/gm npc` commands.
 
+**Compaction resilience — re-read the source, not the compressed context:**
+After context compaction, the GM's impression is a lossy summary of summaries and must not be trusted for specific facts. Before any recap, status summary, or claim about faction standing, cover, or NPC disposition — re-read the *smallest section that covers the claim*:
+- **First stop:** `state.md → ## Live State Flags` — compact key-value facts designed to survive compaction; read this section alone for most recap claims
+- **If not in Live State Flags:** read `state.md → ## Current Situation` and `## Recent Events` (targeted offset — not the full file)
+- **For a specific NPC's attitude or goals:** read only that NPC's entry in `npcs-full.md`
+- **For a past event:** check `## Continuity Archive` in state.md first; escalate to `session-log.md` only if insufficient
+- **For character sheet facts:** read `characters/<name>.md`
+
+One targeted read per claim. The player's trust in world continuity depends on accuracy; session momentum depends on not stalling to reload everything.
+
+**Structured campaign arc steering** (when `state.md → ## Campaign Arc` has `type: structured`):
+
+Read `## Campaign Arc` at every session load alongside `## GM Style Notes`. It contains the required beats for the current chapter. Apply these rules during play:
+
+1. **Telegraph before the beat.** Never deliver a required beat cold. First run the `telegraph_scene` for that chapter — a setup scene that naturally constrains the choice space so the beat feels earned, not forced. A good telegraph gives the player 2–3 apparent paths that all converge on the beat organically.
+
+2. **Steer with world pressure, not walls.** If players drift from the arc, apply indirect pressure first — NPC urgency, environmental escalation, rumour plants, faction moves that make inaction costly. Hard walls ("you can't go that way") are a last resort and should be disguised as fiction, not mechanics.
+
+3. **Mark beats complete.** When a key beat lands, remove it from `outstanding_beats` in state.md at the next `/gm save`. Update `current_chapter` when all beats in a chapter are resolved.
+
+4. **Respect player detours.** A side quest or unexpected tangent is not arc failure — it's GM craft. Run the detour fully. On return, use the `steering_notes` for the current chapter to re-establish momentum without retconning what happened.
+
+5. **Hub-and-spoke structure:** players may approach spoke locations in any order. Each spoke has its own chapter beats. Track which spokes are complete in `outstanding_beats`. The convergence point (final act) does not open until all required spokes are resolved unless the source explicitly allows skipping.
+
+6. **Do not reference the arc document to players.** The arc is a GM tool. Players experience it as natural story progression. Never say "you need to do X before Y" — show them why they want to.
+
+**Dynamic campaign arc steering** (when `state.md → ## Campaign Arc` has `type: dynamic`):
+
+Read `## Campaign Arc` at every session load alongside `## GM Style Notes`. The arc was auto-generated at campaign creation from the world's threat, factions, and setting — and can be revised when major turns redirect the story. Apply these rules:
+
+1. **Know the destination.** The `resolution` field commits to a thematic endpoint — not specific events, but the shape of what resolves. When improvising, always ask: *does this scene move toward or away from that resolution?*
+
+2. **Beats are consequences, not events.** Each beat's `what_changes` defines what must be different in the story after the beat lands, not how it lands. This gives flexibility in HOW the beat arrives while committing to THAT it must arrive. "The party discovers the document" is an event. "The party realizes the threat was designed to outlast any single person" is a consequence — a dozen scenes could deliver it.
+
+3. **Apply `world_pressure` before each beat.** Each beat has a built-in faction or NPC move that creates the conditions for it. Run this as a visible world event — something the party encounters or hears about — before the beat lands. Never deliver a beat cold.
+
+4. **Mark beats at `/gm end`.** After each session, check whether any outstanding beats landed. Mark them complete via `/gm arc advance`. Update `steering_notes` for the next beat.
+
+5. **Revise rather than abandon.** When a player choice significantly redirects the story, use `/gm arc revise`. Update outstanding beats to fit the new direction. Log the revision. The committed shape bends to the story; it does not break it.
+
+6. **The Midpoint Shift (beat 2a) is non-negotiable.** This is the moment where what the party *thought* they were doing gives way to what they're *actually* doing. Without it, act 2 drifts indefinitely. If beat 2a hasn't landed by halfway through your expected session count, escalate world pressure until it does.
+
+7. **All Is Lost (beat 2b) is earned, not punitive.** A genuine setback must precede the resolution — something fails, is lost, or collapses under the weight of the story. It comes from the world's logic, not arbitrary bad luck.
+
+8. **Do not reference the arc document to players.** Players experience it as natural story progression.
+
 **Dice convention:**
 - Roll initiative automatically via `combat.py init` for all combatants at combat start
 - Resolve all NPC/opponent rolls via `dice.py`, show math inline

--- a/SYSTEM-PORTING.md
+++ b/SYSTEM-PORTING.md
@@ -29,6 +29,9 @@ These parts of the skill work identically for any tabletop RPG:
 - **The display companion** — the cinematic display, stat sidebar, and effect pills work for any game. Health bars, resource pips, conditions, turn order — all generic.
 - **Scene detection** — the display companion's scene keyword system works for any setting. It reads the narration and adjusts the background accordingly.
 - **The 12 GM principles** — these apply to every TTRPG. Improvisation, consequence, NPC craft, pacing — universal.
+- **Narrative arc system** — both campaign modes work with any game system. *Improvised campaigns* get an auto-generated three-act dynamic arc at `/gm new` (six beats defined by consequence, not event; tracked and revised across sessions). *Structured campaigns* use `/gm import` to ingest a pre-written source document (PDF, markdown, DOCX, or plain text) and extract acts, chapters, key beats, and steering notes automatically. The arc operates above the system layer — it cares about story shape, not game mechanics.
+- **Campaign import** — `scripts/import_campaign.py` is fully system-agnostic. It extracts text from any source document and hands it to the GM model for structural analysis. The resulting campaign files use the same format regardless of what game system the source describes.
+- **Live State Flags** — the compaction-resilience block in `state.md`; keeps faction stances, NPC dispositions, and cover status anchored in compact key-value form; re-read at any recap to avoid stale impressions from context compression. Universal — works for any campaign.
 
 ---
 

--- a/scripts/import_campaign.py
+++ b/scripts/import_campaign.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""
+import_campaign.py — extract raw text from a campaign source file for /gm import.
+
+Supported input formats:
+  .pdf      — pdftotext (requires poppler) or PyMuPDF fallback
+  .md       — read directly (plain markdown)
+  .txt      — read directly
+  .docx     — python-docx extraction
+
+Usage:
+  python3 import_campaign.py <filepath>            # print full extracted text
+  python3 import_campaign.py <filepath> --info     # print file info + page/word count only
+  python3 import_campaign.py <filepath> --chunk N  # print chunk N of ~4000 words (for large sources)
+  python3 import_campaign.py <filepath> --chunks   # print total number of chunks
+
+Output is UTF-8 plain text, written to stdout. The GM reads this and maps it to campaign files.
+"""
+
+import sys
+import os
+import argparse
+import subprocess
+
+CHUNK_WORDS = 4000  # words per chunk for large sources
+
+
+def extract_pdf(path: str) -> str:
+    """Extract text from PDF using pdftotext (poppler). Falls back to PyMuPDF."""
+    # Try pdftotext first (best quality)
+    result = subprocess.run(
+        ["pdftotext", "-layout", path, "-"],
+        capture_output=True, text=True, timeout=60
+    )
+    if result.returncode == 0 and result.stdout.strip():
+        return result.stdout
+
+    # Fallback: try PyMuPDF if installed
+    try:
+        import fitz  # PyMuPDF
+        doc = fitz.open(path)
+        return "\n\n".join(page.get_text() for page in doc)
+    except ImportError:
+        pass
+
+    raise RuntimeError(
+        "PDF extraction failed. Ensure poppler is installed: brew install poppler"
+    )
+
+
+def strip_frontmatter(text: str) -> str:
+    """Remove YAML frontmatter block (common in markdown files)."""
+    if text.startswith("---"):
+        end = text.find("---", 3)
+        if end != -1:
+            return text[end + 3:].lstrip()
+    return text
+
+
+def extract_docx(path: str) -> str:
+    try:
+        from docx import Document
+        doc = Document(path)
+        return "\n\n".join(p.text for p in doc.paragraphs if p.text.strip())
+    except ImportError:
+        raise RuntimeError(
+            "python-docx not installed. Run: pip3 install python-docx"
+        )
+
+
+def extract(path: str) -> str:
+    ext = os.path.splitext(path)[1].lower()
+
+    if ext == ".pdf":
+        return extract_pdf(path)
+    elif ext in (".md", ".txt", ".markdown"):
+        with open(path, encoding="utf-8", errors="replace") as f:
+            text = f.read()
+        return strip_frontmatter(text)
+    elif ext == ".docx":
+        return extract_docx(path)
+    else:
+        # Unknown extension — try reading as plain text
+        try:
+            with open(path, encoding="utf-8", errors="replace") as f:
+                return f.read()
+        except Exception as e:
+            raise RuntimeError(f"Cannot read {path}: {e}")
+
+
+def word_count(text: str) -> int:
+    return len(text.split())
+
+
+def chunk_text(text: str, chunk_index: int) -> str:
+    """Return chunk N (0-indexed) of ~CHUNK_WORDS words."""
+    words = text.split()
+    start = chunk_index * CHUNK_WORDS
+    end = start + CHUNK_WORDS
+    chunk_words = words[start:end]
+    if not chunk_words:
+        return ""
+    return " ".join(chunk_words)
+
+
+def total_chunks(text: str) -> int:
+    wc = word_count(text)
+    return max(1, (wc + CHUNK_WORDS - 1) // CHUNK_WORDS)
+
+
+def file_info(path: str, text: str) -> str:
+    ext = os.path.splitext(path)[1].lower()
+    wc = word_count(text)
+    chunks = total_chunks(text)
+    lines = [
+        f"File:   {os.path.basename(path)}",
+        f"Type:   {ext or 'unknown'}",
+        f"Words:  {wc:,}",
+        f"Chunks: {chunks}  (--chunk 0 through --chunk {chunks - 1})",
+    ]
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Extract text from a campaign source file.")
+    parser.add_argument("filepath", help="Path to the source file")
+    parser.add_argument("--info", action="store_true", help="Print file info only")
+    parser.add_argument("--chunks", action="store_true", help="Print total chunk count")
+    parser.add_argument("--chunk", type=int, default=None, metavar="N",
+                        help="Print chunk N (0-indexed, ~4000 words each)")
+    args = parser.parse_args()
+
+    if not os.path.exists(args.filepath):
+        print(f"Error: file not found: {args.filepath}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        text = extract(args.filepath)
+    except RuntimeError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    if not text.strip():
+        print("Warning: extracted text is empty. File may be image-only PDF.", file=sys.stderr)
+        sys.exit(1)
+
+    if args.info:
+        print(file_info(args.filepath, text))
+    elif args.chunks:
+        print(total_chunks(text))
+    elif args.chunk is not None:
+        chunk = chunk_text(text, args.chunk)
+        if not chunk:
+            print(f"Error: chunk {args.chunk} out of range (max: {total_chunks(text) - 1})",
+                  file=sys.stderr)
+            sys.exit(1)
+        print(chunk)
+    else:
+        # Print full text
+        print(text)
+
+
+if __name__ == "__main__":
+    main()

--- a/systems/TEMPLATE.md
+++ b/systems/TEMPLATE.md
@@ -204,6 +204,35 @@ This tells the GM what to award and how to track it.
 
 ---
 
+## Campaign Arc Preferences
+
+<!--
+Optional. If your system has strong conventions around campaign structure, note them here.
+The GM will use this to calibrate how it generates or enforces narrative arcs.
+
+Examples:
+  D&D 5e (published adventure): use /gm import to create a structured campaign from the
+    source PDF — arc beats and chapters are extracted automatically.
+  D&D 5e (homebrew): use /gm new for an improvised dynamic arc — auto-generated from
+    the world's threat, factions, and Three Truths at campaign creation.
+  VtM V5 (chronicle): improvised dynamic arc; faction-web structure suits the political
+    focus of most chronicles; hub-and-spoke if running a published module.
+  Cyberpunk RED: improvised arcs with a strong act-2 pressure point recommended;
+    "All Is Lost" beat often lands as a corpo betrayal or mission failure.
+  Narrative / diceless: dynamic arc; beats are thematic rather than mechanical.
+
+If you always import pre-written sources for this system, note the typical structure type:
+  linear         — A→B→C scene chain (dungeon crawl, heist)
+  hub-and-spoke  — central hub + spoke locations in player-driven order (hexcrawl, published modules)
+  faction-web    — multi-faction city/complex with overlapping arcs (political, intrigue)
+-->
+
+**Preferred campaign mode:** [improvised / imported / either]
+**Typical arc structure:** [dynamic / structured — and if structured: linear / hub-and-spoke / faction-web]
+**Genre conventions:** [any pacing or arc notes specific to this system's genre]
+
+---
+
 ## Additional System Notes
 
 <!--

--- a/templates/state.md
+++ b/templates/state.md
@@ -30,8 +30,123 @@
 ## Active Combat
 *(none)*
 
+## Live State Flags
+*Structured facts designed to survive context compaction. Re-read this section before any recap, status summary, or claim about cover, NPC stance, or faction standing. Update at every /gm save.*
+
+**Cover / party position:**
+*(none established)*
+
+**Faction stances** *(only list factions with non-neutral standing toward the party)*:
+*(none established)*
+
+**NPC dispositions** *(only list NPCs with changed or notable standing)*:
+*(none established)*
+
+## Campaign Arc
+*(sandbox campaigns: set `type: sandbox` — no arc tracking)*
+*(structured campaigns: populated by /gm import — use structured format)*
+*(improvised campaigns: auto-generated at /gm new — use dynamic format)*
+```yaml
+# --- DYNAMIC ARC (improvised campaigns, auto-generated at /gm new) ---
+type: dynamic
+arc_number: 1          # increments each time /gm arc new generates a successor arc
+generated: "<date>"
+revised: null
+
+theme: "<one sentence — what this story is ultimately about, not what happens but what it means>"
+resolution: "<committed endpoint shape — not specific events, but the emotional/thematic truth if the party succeeds>"
+
+acts:
+  - act: 1
+    title: "Setup"
+    drive: "<what the party wants or needs at the start>"
+    beats:
+      - id: "1a"
+        label: "<Inciting Incident>"
+        what_changes: "<before vs. after — what's fundamentally different once this lands>"
+        world_pressure: "<specific faction/NPC move that makes this beat feel inevitable>"
+        status: current     # current | complete | skipped
+      - id: "1b"
+        label: "<Complication>"
+        what_changes: "<what the party learns that makes the problem bigger or stranger than it first appeared>"
+        world_pressure: "<what creates this pressure>"
+        status: pending
+
+  - act: 2
+    title: "Confrontation"
+    drive: "<what the party is now pursuing — may differ from act 1>"
+    beats:
+      - id: "2a"
+        label: "<Midpoint Shift>"
+        what_changes: "<the thing they thought was true / the goal they thought they had changes>"
+        world_pressure: "<what forces this realization>"
+        status: pending
+      - id: "2b"
+        label: "<All Is Lost>"
+        what_changes: "<a genuine setback — something fails, is lost, or collapses>"
+        world_pressure: "<what drives this failure>"
+        status: pending
+
+  - act: 3
+    title: "Resolution"
+    drive: "<what the party now understands and is fighting for>"
+    beats:
+      - id: "3a"
+        label: "<Final Confrontation>"
+        what_changes: "<the decisive moment the campaign turns on>"
+        world_pressure: "<the escalated form of the original threat>"
+        status: pending
+      - id: "3b"
+        label: "<Resolution>"
+        what_changes: "<what's different about the world and the characters after>"
+        world_pressure: "<what factions/NPCs do with the outcome>"
+        status: pending
+
+current_act: 1
+current_beat: "1a"
+
+outstanding_beats:
+  - "1a"
+  - "1b"
+  - "2a"
+  - "2b"
+  - "3a"
+  - "3b"
+
+steering_notes: >
+  <Active guidance — what world pressure to apply to reach the current beat without forcing it.
+  Update at each /gm end when a beat advances or needs active steering.>
+
+revision_log: []
+
+# --- STRUCTURED ARC (imported campaigns, populated by /gm import) ---
+# type: structured
+# source: "<title>"
+# structure: linear   # linear | hub-and-spoke | faction-web
+# current_act: 1
+# current_chapter: "<chapter name>"
+# acts:
+#   - act: 1
+#     title: "<act title>"
+#     chapters:
+#       - id: "1.1"
+#         title: "<chapter name>"
+#         location: "<primary location>"
+#         key_beats: ["<beat>", "<beat>"]
+#         telegraph_scene: "<setup scene>"
+#         branching_notes: "<how player choices can vary>"
+#         status: current
+# outstanding_beats: ["<beat>"]
+# steering_notes: >
+#   <How to guide players toward outstanding beats without forcing.>
+```
+
+## Arc History
+*(populated by /gm arc new when a completed arc is succeeded by a new one — one entry per completed arc)*
+*(leave empty until the first arc completes)*
+
 ## Session Flags
-*(tutor_mode, etc. — session-scoped flags set via /dnd commands)*
+*(tutor_mode, etc. — session-scoped flags set via /gm commands)*
 
 ## GM Style Notes
 *Distilled calibration for this specific player — read at every /gm load, updated at /gm end only when a genuinely new pattern emerges.*


### PR DESCRIPTION
## Summary

- **Narrative arc system** — two steering modes added to `SKILL.md`: structured arc (6 rules for imported campaigns — telegraph, world pressure, hub-and-spoke) and dynamic arc (8 rules for improvised campaigns — beats as consequences, Midpoint Shift, All Is Lost)
- **Compaction resilience** — `## Live State Flags` guidance in `SKILL.md`: re-read the source not the compressed context; hierarchical lookup order (Live State Flags → Current Situation → NPC entry → Continuity Archive → character sheet); one targeted read per claim
- **`/gm import`** — full procedure in `SKILL-commands.md`; `scripts/import_campaign.py` added (PDF/MD/DOCX/TXT extraction, `--info`/`--chunks`/`--chunk N` flags); structure-type detection (linear/hub-and-spoke/faction-web)
- **`/gm arc`** — status/advance/revise/view/new commands; arc continuation when 3b is marked complete; arc_number increments; completed arcs archived to `## Arc History`
- **`/gm new` step 14** — arc generation step added; model-agnostic with note recommending Opus-class; offers sandbox mode if declined
- **`/gm save`** — expanded from one sentence to a full 6-step procedure: session log, World State sync, Live State Flags update, arc check, session log archival
- **`templates/state.md`** — added `## Live State Flags`, `## Campaign Arc` (full dynamic + structured yaml), and `## Arc History` sections
- **`SYSTEM-PORTING.md`** — arc system, campaign import, and Live State Flags added to "What's universal"
- **`systems/TEMPLATE.md`** — added optional `## Campaign Arc Preferences` section

## Skipped / deferred

- Easter-egg content from `dnd5e_supplemental.json` — left as claude-dnd-skill specific
- D&D-specific Inspiration, XP events — deferred to `systems/dnd5e/system.md` extensions

## Test plan

- [ ] Run `/gm new`, reach step 14, decline arc — confirm `type: sandbox` written
- [ ] Run `/gm new`, reach step 14, accept arc — confirm six beats written to state.md
- [ ] Run `/gm import` on a sample PDF — confirm structure detection and campaign file generation
- [ ] Run `/gm arc status` — confirm correct beat/act displayed
- [ ] Run `/gm arc advance 1a` — confirm beat marked complete, steering_notes updated
- [ ] Run `/gm arc revise` — confirm revision_log updated, outstanding beats adjusted
- [ ] Run `/gm save` — confirm all 6 steps execute, Live State Flags updated, arc check fires