### PR TITLE
sync: send.py reliability + heredoc gotcha warning from claude-dnd-skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 display/.token
 display/stats.json
 display/text_log.json
+display/session_tail.json
 display/app.log
 display/app.pid
 display/cert.pem

--- a/SKILL-branches.md
+++ b/SKILL-branches.md
@@ -6,7 +6,7 @@ This file is always in context. When any command or state transition occurs, loo
 
 ## `/gm load <name>`
 
-**No questions. Four steps. Do them in order and stop.**
+**No questions. Five steps. Do them in order and stop.**
 
 **Step 1 — Check display state:**
 ```
@@ -14,14 +14,33 @@ bash -c 'f=<skill-base>/display/app.pid; test -f "$f" && kill -0 $(cat "$f") 2>/
 ```
 Store result as `display=ON` or `display=OFF`. Do not run `start-display.sh`.
 
-**Step 2 — Read these three files:**
+**Step 2 — If `display=ON`, sync campaign and replay previous session tail:**
+
+Skip this step entirely if `display=OFF`.
+
+1. Register the active campaign (writes `.campaign` and reloads the per-campaign tail buffer):
+   ```
+   python3 <skill-base>/display/send.py --set-campaign <name> < /dev/null
+   ```
+2. Read `~/open-tabletop-gm/campaigns/<name>/session_tail.json`. **The campaign-side path is the authoritative one — do NOT read** the legacy/fallback at `<skill-base>/display/session_tail.json`; that file may exist from older sessions or other campaigns and will mislead the replay. If the campaign-side file does not exist, skip the rest of this step (display starts blank).
+3. For each entry in the tail array, send it via `send.py` using the entry's keys:
+   - `player` key present → `send.py --player <name>` with text via stdin
+   - `npc` key present → `send.py --npc <name>` with text via stdin
+   - `dice` key present → `send.py --dice` with text via stdin
+   - `tutor` key present → `send.py --tutor` with text via stdin
+   - `action` key present → `send.py --action <name>` with text via stdin
+   - none of the above → `send.py` with text via stdin (plain narration)
+
+   Send entries in array order. The display will render them as the previous session's last exchanges, restoring continuity for any reconnecting browser.
+
+**Step 3 — Read these three files:**
 1. `~/open-tabletop-gm/campaigns/<name>/state.md`
 2. `~/open-tabletop-gm/campaigns/<name>/world.md`
 3. `~/open-tabletop-gm/campaigns/<name>/npcs.md`
 
-**Step 3 — Deliver opening narration as plain text.** Do not run any bash commands. Do not read any more files. Just write the narration. Set the scene from what you read. End with a question to the player.
+**Step 4 — Deliver opening narration as plain text.** Do not run any bash commands. Do not read any more files. Just write the narration. Set the scene from what you read. End with a question to the player.
 
-**Step 4 — Enter active GM mode.** `/gm` prefix not needed. Characters and system rules load on demand during the session.
+**Step 5 — Enter active GM mode.** `/gm` prefix not needed. Characters and system rules load on demand during the session.
 
 ---
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -207,6 +207,8 @@ ROLL=$(python3 scripts/dice.py d20+5 --silent)
 echo "Aldric — Insight: d20+5 = $ROLL → [brief outcome]" | python3 display/send.py --dice
 ```
 
+⚠ **Heredoc gotcha:** The `<< 'GMEND'` form (single-quoted terminator) **blocks variable expansion** — `${ROLL}` will be sent literally, not expanded. Use it for static narration, but for dice/anything with shell variables, **always use `echo`/`printf` piping** (as in the example above) or an unquoted `<< GMEND` heredoc. Mixing the two is the most common send-formatting bug.
+
 *NPC dialogue* — when an NPC speaks more than a line:
 ```bash
 python3 display/send.py --npc "NPC Name" << 'GMEND'

--- a/display/gm-display-app.py
+++ b/display/gm-display-app.py
@@ -769,6 +769,72 @@ def _load_log() -> None:
 _load_log()
 
 
+# ─── Session tail buffer ──────────────────────────────────────────────────────
+# Rolling buffer of the last 30 text events — written to session_tail.json after
+# every /chunk POST so it survives crashes. Read at /gm load for display replay
+# of the previous session's last exchanges.
+#
+# The text_log buffer above (maxlen=60) drives in-session browser-reconnect
+# replay. The tail buffer (maxlen=30) is a parallel, leaner record stamped with
+# the campaign name so cross-campaign replay does not bleed.
+#
+# Path is campaign-specific so tails from different campaigns do not overwrite
+# each other. The fallback at the display dir is used only when no campaign is
+# registered (first-run state).
+_TAIL_FALLBACK = os.path.join(_DISPLAY_DIR, "session_tail.json")
+_tail_buffer: deque = deque(maxlen=30)
+_tail_lock = threading.Lock()
+
+
+def _get_tail_file() -> str:
+    """Return the campaign-specific tail path, or the fallback display-dir path."""
+    try:
+        camp = open(CAMP_FILE).read().strip()
+        if camp:
+            return os.path.expanduser(
+                f"~/open-tabletop-gm/campaigns/{camp}/session_tail.json"
+            )
+    except Exception:
+        pass
+    return _TAIL_FALLBACK
+
+
+def _persist_tail() -> None:
+    """Write the current tail buffer to disk. Called after every chunk."""
+    try:
+        with _tail_lock:
+            data = list(_tail_buffer)
+        with open(_get_tail_file(), "w") as f:
+            json.dump(data, f)
+    except Exception:
+        pass
+
+
+def _load_tail() -> None:
+    """Load the previously persisted tail. Called at startup and on campaign switch.
+    Filters by campaign stamp so a stale shared file cannot bleed entries from
+    another campaign into the active one."""
+    try:
+        with open(_get_tail_file()) as f:
+            data = json.load(f)
+        try:
+            current_camp = open(CAMP_FILE).read().strip()
+        except Exception:
+            current_camp = ""
+        with _tail_lock:
+            _tail_buffer.clear()
+            for item in data[-30:]:
+                item_camp = item.get("_camp", "")
+                if current_camp and item_camp and item_camp != current_camp:
+                    continue
+                _tail_buffer.append(item)
+    except Exception:
+        pass
+
+
+_load_tail()
+
+
 # ─── Character / combat stats ─────────────────────────────────────────────────
 # Stored as {"players": [...], "turn_order": {...}|null}
 # Players are merged by name so partial updates (just HP, just XP) work.
@@ -889,13 +955,15 @@ def chunk():
         return "Forbidden", 403
     data = request.get_json(silent=True) or {}
 
-    # Campaign registration — write .campaign file and reload log for correct per-campaign
-    # replay. Sent by send.py --set-campaign at /gm load. May arrive with or without text.
+    # Campaign registration — write .campaign file and reload log + tail for correct
+    # per-campaign replay. Sent by send.py --set-campaign at /gm load. May arrive with
+    # or without text.
     if "campaign" in data:
         try:
             with open(CAMP_FILE, "w") as f:
                 f.write(str(data["campaign"]).strip())
             _load_log()
+            _load_tail()
         except Exception:
             pass
 
@@ -951,10 +1019,22 @@ def chunk():
     elif is_tutor:
         log_entry["tutor"] = True
 
+    # Stamp campaign onto the tail entry so cross-campaign replay can filter
+    # and a stale shared file does not bleed into the active session.
+    try:
+        _camp_stamp = open(CAMP_FILE).read().strip()
+        if _camp_stamp:
+            log_entry["_camp"] = _camp_stamp
+    except Exception:
+        pass
+
     with _text_log_lock:
         _text_log.append(log_entry)
+    with _tail_lock:
+        _tail_buffer.append(log_entry)
 
     _persist_log()
+    _persist_tail()
     _broadcast(payload)
     return "", 204
 

--- a/display/send.py
+++ b/display/send.py
@@ -70,7 +70,9 @@ _SCHEME = _SCHEME_FILE.read_text().strip() if _SCHEME_FILE.exists() else "http"
 FLASK_URL   = f"{_SCHEME}://localhost:5001/chunk"
 STATS_URL   = f"{_SCHEME}://localhost:5001/stats"
 TOKEN_FILE  = str(_DIR / ".token")
-TIMEOUT     = 2.0
+TIMEOUT     = 8.0
+RETRIES     = 1                # one retry on timeout/connection error
+CHUNK_LIMIT = 3500             # paragraph-split text bodies above this many chars
 
 # SSL context — only used when running HTTPS (self-signed cert)
 if _SCHEME == "https":
@@ -88,15 +90,70 @@ def _read_token() -> str:
         return ""
 
 
-def _post(url: str, data: bytes, token: str) -> None:
+def _post(url: str, data: bytes, token: str) -> bool:
+    """POST data with retries. Logs failures to stderr (visible in shell output).
+
+    Returns True on success, False after all retries exhausted. Display being
+    offline is the only "expected" failure mode; everything else is logged so
+    transient timeouts / dropped sends do not silently lose narration.
+    """
     headers = {"Content-Type": "application/json"}
     if token:
         headers["X-DND-Token"] = token
     req = urllib.request.Request(url, data=data, headers=headers, method="POST")
-    try:
-        urllib.request.urlopen(req, timeout=TIMEOUT, context=_SSL_CTX)
-    except Exception:
-        pass  # Display not running — fail silently
+    attempts = RETRIES + 1
+    last_err: "Exception | None" = None
+    for i in range(attempts):
+        try:
+            urllib.request.urlopen(req, timeout=TIMEOUT, context=_SSL_CTX)
+            return True
+        except (urllib.error.URLError, ConnectionError, TimeoutError) as e:
+            # Connection refused = display not running. First-attempt fail-fast.
+            inner = getattr(e, "reason", e)
+            if isinstance(inner, ConnectionRefusedError) or "Connection refused" in str(inner):
+                return False
+            last_err = e
+            if i < attempts - 1:
+                time.sleep(0.5 * (i + 1))
+        except Exception as e:
+            last_err = e
+            if i < attempts - 1:
+                time.sleep(0.5 * (i + 1))
+    print(f"send.py: POST {url} failed after {attempts} attempts: {last_err}",
+          file=sys.stderr)
+    return False
+
+
+def _split_paragraphs(text: str, limit: int = CHUNK_LIMIT) -> list:
+    """Split a long text body into chunks no larger than `limit` chars.
+
+    Splits on paragraph boundaries (`\\n\\n`) when possible. Each chunk
+    preserves the original whitespace. If a single paragraph exceeds the
+    limit, it is hard-split on character boundary as a last resort.
+    """
+    if len(text) <= limit:
+        return [text]
+    paragraphs = text.split("\n\n")
+    chunks: list = []
+    cur = ""
+    for p in paragraphs:
+        candidate = (cur + "\n\n" + p) if cur else p
+        if len(candidate) <= limit:
+            cur = candidate
+            continue
+        # Flush whatever we have, start a new chunk with this paragraph
+        if cur:
+            chunks.append(cur)
+            cur = ""
+        # If this single paragraph is itself too big, hard-split it
+        if len(p) > limit:
+            for i in range(0, len(p), limit):
+                chunks.append(p[i:i + limit])
+        else:
+            cur = p
+    if cur:
+        chunks.append(cur)
+    return chunks
 
 
 def _build_stats_payload(args) -> "dict | None":
@@ -300,19 +357,21 @@ def main() -> None:
         _post(FLASK_URL, json.dumps(payload).encode("utf-8"), token)
     # ── Text send ─────────────────────────────────────────────────────────────
     elif text.strip():
-        payload = {"text": text}
-        if args.action:
-            payload["action"] = args.action
-        elif args.player:
-            payload["player"] = args.player
-        elif args.npc:
-            payload["npc"] = args.npc
-        elif args.dice:
-            payload["dice"] = True
-        elif args.tutor:
-            payload["tutor"] = True
+        chunks = _split_paragraphs(text)
+        for chunk in chunks:
+            payload = {"text": chunk}
+            if args.action:
+                payload["action"] = args.action
+            elif args.player:
+                payload["player"] = args.player
+            elif args.npc:
+                payload["npc"] = args.npc
+            elif args.dice:
+                payload["dice"] = True
+            elif args.tutor:
+                payload["tutor"] = True
 
-        _post(FLASK_URL, json.dumps(payload).encode("utf-8"), token)
+            _post(FLASK_URL, json.dumps(payload).encode("utf-8"), token)
 
     # ── Stat send (bundled) ───────────────────────────────────────────────────
     stats_payload = _build_stats_payload(args)


### PR DESCRIPTION
## Summary

Three coordinated fixes from claude-dnd-skill to make display sync robust and continuity-preserving across sessions.

### 1. display/send.py — reliability against silent drops
- `TIMEOUT` 2.0 → 8.0 seconds
- One retry with 0.5s backoff on transient timeouts/URL errors
- Fail-fast on connection-refused (display offline) — no retry, exits clean
- Visible stderr message on final failure (replaces the silent `except: pass` that was eating drops)
- Auto-chunk text bodies on `\n\n` paragraph boundaries at 3500 chars; hard-split fallback for over-long single paragraphs

The original failure mode: a single send.py invocation with a long narration body could time out at 2s with the Flask server still processing, the exception was swallowed, and the GM had no signal that the block never reached the display. Higher timeout + retry + visible logging + chunking eliminates the silent-drop class.

### 2. display/gm-display-app.py — per-campaign session tail buffer
- 30-entry rolling tail buffer parallel to the existing 60-entry text_log
- Persists to `~/open-tabletop-gm/campaigns/<name>/session_tail.json` after every `/chunk` POST so it survives crashes and a fresh display restart
- Each entry stamped with the active campaign name (`_camp`); a stale fallback file at `display/session_tail.json` cannot bleed entries from one campaign into another at load time
- `/chunk` handler reloads the tail buffer when a `campaign` field arrives (sent by `send.py --set-campaign`), parallel to the existing `_load_log()` call
- `_get_tail_file()` / `_persist_tail()` / `_load_tail()` mirror the established log helpers and degrade gracefully if the campaign dir is missing

### 3. SKILL-branches.md — `/gm load` replay step
- `/gm load` grows from four steps to five
- New Step 2 runs only when `display=ON`: register the active campaign with `send.py --set-campaign`, then read the campaign-side `session_tail.json` and replay each entry via `send.py` with the appropriate flag (`--player`, `--npc`, `--dice`, `--tutor`, `--action`, or plain)
- Explicitly forbids the legacy display-dir fallback path; that file is the cross-campaign default and will mislead replay if read directly
- Step 2 is a no-op when `display=OFF` — preserves the offline `/gm load` shape

### 4. SKILL.md — heredoc gotcha warning
Adds a one-paragraph warning right after the dice-roll `echo` example: `<< 'GMEND'` (single-quoted) blocks `${VAR}` expansion, so dice rolls written that way send the literal `${ROLL}` text. The existing example uses `echo "...$ROLL..." | send.py` correctly; the warning makes the trap explicit so future authoring doesn't trip on it.

### 5. .gitignore — fallback tail path
Adds `display/session_tail.json` so a first-run-without-campaign tail does not get committed.

## Validation

- `python3 -m py_compile display/gm-display-app.py display/send.py` — clean
- `_split_paragraphs` smoke test: small (1 chunk), 3-paragraph (3 chunks at boundaries), oversized single paragraph (hard-split) all correct
- Live test of the tail-write path with a scratch campaign: file written to `~/open-tabletop-gm/campaigns/<name>/session_tail.json`, all four entry types preserved (plain, player, npc, dice), each entry stamped with `_camp`
- Opsec scan: no campaign data, player names, NPC names, place names, or `/Users/` paths in diff
- `git check-ignore display/session_tail.json` — confirmed ignored

## Test plan

- [ ] Start the display, register a campaign, send a few entries, stop the display, restart, run `/gm load <campaign>` — verify the previous entries replay onto the display
- [ ] Same flow but switch campaigns mid-stream — verify the previous campaign's tail does not bleed
- [ ] Run a long narration through `send.py` (over 3500 chars with `\n\n` separators); verify it renders as multiple chunks
- [ ] Stop the display, run a `send.py` call; verify it exits clean (no retry storm)
- [ ] Run `send.py` against a slow/unresponsive endpoint; verify the stderr failure message appears