### PR TITLE
Sync: GM_CAMPAIGN_ROOT, /gm path, /gm update from claude-dnd-skill

### DIFF
--- a/SKILL-branches.md
+++ b/SKILL-branches.md
@@ -53,6 +53,29 @@ Start or stop the display companion independently of session load.
 
 ---
 
+## `/gm path [<new-path> | reset]`
+
+View or configure where campaign and character data is stored. Wraps the `GM_CAMPAIGN_ROOT` env var (default `~/open-tabletop-gm`).
+
+- No args → `python3 <skill-base>/scripts/path_config.py` and show output.
+- New path → `python3 <skill-base>/scripts/path_config.py set <path>`. Confirm to user, then remind them the change only takes effect in new shells (or after they `source` their rc on macOS/Linux).
+- `reset` → `python3 <skill-base>/scripts/path_config.py reset`.
+
+Persistence is via shell rc on macOS/Linux and via `setx` on Windows. Existing campaigns are not auto-migrated; `paths.find_campaign()` handles legacy fallback + copy-on-access.
+
+---
+
+## `/gm update [--check]`
+
+Pull the latest skill changes from `origin/main`.
+
+- No args → `python3 <skill-base>/scripts/update_skill.py` and stream output (script prompts before pulling).
+- `--check` → `python3 <skill-base>/scripts/update_skill.py --check` — report status without pulling.
+- The script refuses to update if the working tree is dirty and uses `--ff-only` so it never silently merges divergent history.
+- After a successful pull, remind the user to restart their GM session so the new `SKILL.md` and `SKILL-branches.md` are reloaded.
+
+---
+
 ## ACTIVE — Narration Turn
 
 Each player message during an active session:

--- a/SKILL-commands.md
+++ b/SKILL-commands.md
@@ -34,6 +34,8 @@ Do NOT run `git init` or any git commands in campaign directories.
 | `/gm npc <name>` | Generate or retrieve an NPC. Write to npcs.md / npcs-full.md. |
 | `/gm import <filepath> [campaign-name]` | Import a pre-written campaign source (PDF, MD, DOCX, TXT). See `/gm import` procedure below. |
 | `/gm arc [status\|advance\|revise\|view]` | Manage the dynamic campaign arc. See `/gm arc` procedure below. |
+| `/gm path [<new-path>\|reset]` | View or configure where campaign data is stored (`GM_CAMPAIGN_ROOT`). Follow `/gm path` branch. |
+| `/gm update [--check]` | Pull the latest skill changes from origin/main. Follow `/gm update` branch. |
 
 ---
 

--- a/display/dm_help.py
+++ b/display/dm_help.py
@@ -30,7 +30,12 @@ LOCK_FILE    = _DISPLAY_DIR / ".help-lock"
 LOG_FILE     = _DISPLAY_DIR / "text_log.json"
 SEND_PY      = _DISPLAY_DIR / "send.py"
 
-CAMPAIGNS_DIR = pathlib.Path("~/open-tabletop-gm/campaigns").expanduser()
+_SCRIPTS_DIR = _DISPLAY_DIR.parent / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+from paths import campaigns_dir as _campaigns_dir
+
+CAMPAIGNS_DIR = _campaigns_dir()
 
 # Sections to extract from state.md.
 # Deliberately excludes "## Open Threads & Rumours" and "## Recent Events"

--- a/display/gm-display-app.py
+++ b/display/gm-display-app.py
@@ -50,6 +50,8 @@ except Exception:
     _lookup = None          # type: ignore
     _SRD_AVAILABLE = False
 
+from paths import campaign_dir as _campaign_dir
+
 # Audio module — degrades silently if numpy not installed
 import sys as _sys
 if _DISPLAY_DIR not in _sys.path:
@@ -730,9 +732,7 @@ def _get_log_file() -> str:
     try:
         camp = open(CAMP_FILE).read().strip()
         if camp:
-            return os.path.expanduser(
-                f"~/open-tabletop-gm/campaigns/{camp}/text_log.json"
-            )
+            return str(_campaign_dir(camp) / "text_log.json")
     except Exception:
         pass
     return _LOG_FALLBACK
@@ -791,9 +791,7 @@ def _get_tail_file() -> str:
     try:
         camp = open(CAMP_FILE).read().strip()
         if camp:
-            return os.path.expanduser(
-                f"~/open-tabletop-gm/campaigns/{camp}/session_tail.json"
-            )
+            return str(_campaign_dir(camp) / "session_tail.json")
     except Exception:
         pass
     return _TAIL_FALLBACK

--- a/scripts/calendar.py
+++ b/scripts/calendar.py
@@ -44,16 +44,13 @@ Usage:
 import json
 import os
 import pathlib
-
-_CAMPAIGNS_DIR = pathlib.Path(
-    os.environ.get(
-        "OPENTTG_CAMPAIGNS_DIR",
-        str(pathlib.Path.home() / ".local" / "share" / "open-tabletop-gm" / "campaigns")
-    )
-)
 import sys
 import subprocess
 import argparse
+
+from paths import campaigns_dir as _campaigns_dir
+
+_CAMPAIGNS_DIR = _campaigns_dir()
 
 _SCRIPTS_DIR = pathlib.Path(__file__).parent
 SEND_PY = str(_SCRIPTS_DIR.parent / "display" / "send.py")

--- a/scripts/campaign_search.py
+++ b/scripts/campaign_search.py
@@ -22,12 +22,9 @@ import pathlib
 import argparse
 import re
 
-CAMPAIGNS_DIR = str(pathlib.Path(
-    os.environ.get(
-        "OPENTTG_CAMPAIGNS_DIR",
-        str(pathlib.Path.home() / ".local" / "share" / "open-tabletop-gm" / "campaigns")
-    )
-))
+from paths import campaigns_dir as _campaigns_dir
+
+CAMPAIGNS_DIR = str(_campaigns_dir())
 
 FILE_MAP = {
     "state":   "state.md",

--- a/scripts/path_config.py
+++ b/scripts/path_config.py
@@ -1,0 +1,153 @@
+"""
+path_config.py — view and configure GM_CAMPAIGN_ROOT.
+
+Usage:
+    python3 path_config.py                  # show current paths
+    python3 path_config.py set <path>       # persist GM_CAMPAIGN_ROOT
+    python3 path_config.py reset            # remove persisted value
+
+Persists by writing the env var to the user's shell rc on macOS/Linux, or via
+`setx` on Windows. The change does not affect the parent shell — users must
+open a new shell or `source` their rc to pick it up.
+"""
+import argparse
+import os
+import pathlib
+import re
+import subprocess
+import sys
+
+from paths import _root, campaigns_dir, characters_dir
+
+SHELLRC_CANDIDATES = [
+    pathlib.Path("~/.zshrc").expanduser(),
+    pathlib.Path("~/.bashrc").expanduser(),
+    pathlib.Path("~/.bash_profile").expanduser(),
+]
+EXPORT_RE = re.compile(r'^\s*export\s+GM_CAMPAIGN_ROOT=.*\n?', re.MULTILINE)
+
+
+def _is_windows() -> bool:
+    return os.name == "nt"
+
+
+def _shellrc() -> pathlib.Path:
+    shell = os.environ.get("SHELL", "")
+    if "zsh" in shell:
+        return pathlib.Path("~/.zshrc").expanduser()
+    if "bash" in shell:
+        for p in (pathlib.Path("~/.bashrc").expanduser(),
+                  pathlib.Path("~/.bash_profile").expanduser()):
+            if p.exists():
+                return p
+    for p in SHELLRC_CANDIDATES:
+        if p.exists():
+            return p
+    return pathlib.Path("~/.zshrc").expanduser()
+
+
+def show() -> None:
+    raw = os.environ.get("GM_CAMPAIGN_ROOT", "").strip()
+    root = _root()
+    cdir = campaigns_dir()
+    chdir = characters_dir()
+    n_campaigns = len([p for p in cdir.iterdir() if p.is_dir()]) if cdir.exists() else 0
+    n_chars = len(list(chdir.glob("*.md"))) if chdir.exists() else 0
+    source = "from GM_CAMPAIGN_ROOT" if raw else "default — GM_CAMPAIGN_ROOT not set"
+    print(f"Campaign root: {root}  ({source})")
+    print(f"  campaigns/   → {cdir}  ({n_campaigns} campaigns)")
+    print(f"  characters/  → {chdir}  ({n_chars} characters)")
+    if not raw:
+        print("  Tip: /gm path <new-path> to move data (e.g. ~/Dropbox/gm)")
+
+
+def _set_windows(target: pathlib.Path) -> None:
+    result = subprocess.run(
+        ["setx", "GM_CAMPAIGN_ROOT", str(target)],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        sys.stderr.write(result.stderr or "setx failed\n")
+        raise SystemExit(result.returncode)
+    print(f"Set GM_CAMPAIGN_ROOT={target}")
+    print("Persisted via setx (user environment).")
+    print("Open a new terminal for the change to take effect.")
+
+
+def _set_unix(target: pathlib.Path) -> None:
+    rc = _shellrc()
+    line = f'export GM_CAMPAIGN_ROOT="{target}"'
+    existing = rc.read_text() if rc.exists() else ""
+    if EXPORT_RE.search(existing):
+        new_text = EXPORT_RE.sub(line + "\n", existing)
+    else:
+        sep = "" if existing.endswith("\n") or not existing else "\n"
+        new_text = f"{existing}{sep}{line}\n"
+    rc.write_text(new_text)
+    print(f"Set GM_CAMPAIGN_ROOT={target}")
+    print(f"Persisted to {rc}")
+    print(f'Run: export GM_CAMPAIGN_ROOT="{target}"  (or open a new shell)')
+
+
+def set_path(new: str) -> None:
+    target = pathlib.Path(new).expanduser().resolve()
+    target.mkdir(parents=True, exist_ok=True)
+    if _is_windows():
+        _set_windows(target)
+    else:
+        _set_unix(target)
+
+
+def _reset_windows() -> None:
+    result = subprocess.run(
+        ["reg", "delete", "HKCU\\Environment", "/F", "/V", "GM_CAMPAIGN_ROOT"],
+        capture_output=True, text=True,
+    )
+    if result.returncode == 0:
+        print("Removed GM_CAMPAIGN_ROOT from user environment.")
+        print("Open a new terminal for the change to take effect.")
+    else:
+        print("No persisted value found in user environment.")
+
+
+def _reset_unix() -> None:
+    rc = _shellrc()
+    if not rc.exists():
+        print(f"No persisted value (no {rc}).")
+        return
+    text = rc.read_text()
+    if not EXPORT_RE.search(text):
+        print(f"No GM_CAMPAIGN_ROOT line found in {rc}.")
+        return
+    cleaned = EXPORT_RE.sub("", text)
+    cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
+    rc.write_text(cleaned)
+    print(f"Removed GM_CAMPAIGN_ROOT from {rc}.")
+    print("Run: unset GM_CAMPAIGN_ROOT  (or open a new shell)")
+
+
+def reset() -> None:
+    if _is_windows():
+        _reset_windows()
+    else:
+        _reset_unix()
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    sub = p.add_subparsers(dest="cmd")
+    sub.add_parser("show")
+    s = sub.add_parser("set"); s.add_argument("path")
+    sub.add_parser("reset")
+    args = p.parse_args()
+    if args.cmd == "set":
+        set_path(args.path)
+    elif args.cmd == "reset":
+        reset()
+    else:
+        show()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/paths.py
+++ b/scripts/paths.py
@@ -1,0 +1,81 @@
+"""
+paths.py — canonical path resolution for open-tabletop-gm campaign and character data.
+
+All scripts that need to locate campaign or character files should import from
+here rather than hardcoding ~/open-tabletop-gm/. Set GM_CAMPAIGN_ROOT to move
+your data anywhere — iCloud, Dropbox, network share, etc. Defaults to
+~/open-tabletop-gm.
+
+Usage:
+    from paths import campaigns_dir, characters_dir, campaign_dir, find_campaign
+
+Environment:
+    GM_CAMPAIGN_ROOT    Root of campaign data tree. Default: ~/open-tabletop-gm
+                        Example: export GM_CAMPAIGN_ROOT=~/Dropbox/gm
+"""
+
+import os
+import pathlib
+import shutil
+import sys
+
+_DEFAULT_ROOT = pathlib.Path("~/open-tabletop-gm").expanduser()
+
+
+def _root() -> pathlib.Path:
+    """Return the configured data root, expanded and absolute."""
+    raw = os.environ.get("GM_CAMPAIGN_ROOT", "")
+    if raw.strip():
+        return pathlib.Path(raw.strip()).expanduser().resolve()
+    return _DEFAULT_ROOT
+
+
+def campaigns_dir() -> pathlib.Path:
+    """Return the campaigns directory under the configured root."""
+    return _root() / "campaigns"
+
+
+def characters_dir() -> pathlib.Path:
+    """Return the global characters directory under the configured root."""
+    return _root() / "characters"
+
+
+def campaign_dir(name: str) -> pathlib.Path:
+    """Return the directory for a specific campaign under the configured root."""
+    return campaigns_dir() / name
+
+
+def find_campaign(name: str) -> pathlib.Path:
+    """Locate a campaign directory, with legacy fallback and optional migration.
+
+    Resolution order:
+    1. $GM_CAMPAIGN_ROOT/campaigns/<name>/  — configured root (or default)
+    2. ~/open-tabletop-gm/campaigns/<name>/ — legacy default (only checked when
+       GM_CAMPAIGN_ROOT is set to a *different* path)
+
+    When a campaign is found at the legacy path and the configured root is custom,
+    the campaign is copied to the configured root so subsequent sessions use the
+    new location. The original is left in place (no files are deleted).
+
+    Returns the path to the campaign directory (may not exist if not found anywhere).
+    """
+    configured = campaign_dir(name)
+    if configured.exists():
+        return configured
+
+    custom_root = os.environ.get("GM_CAMPAIGN_ROOT", "").strip()
+    if not custom_root:
+        return configured
+
+    legacy = _DEFAULT_ROOT / "campaigns" / name
+    if not legacy.exists():
+        return configured
+
+    configured.parent.mkdir(parents=True, exist_ok=True)
+    print(
+        f"[paths] Campaign '{name}' found at legacy path {legacy}\n"
+        f"[paths] Copying to {configured} (original kept in place)",
+        file=sys.stderr,
+    )
+    shutil.copytree(str(legacy), str(configured))
+    return configured

--- a/scripts/tracker.py
+++ b/scripts/tracker.py
@@ -45,12 +45,9 @@ import argparse
 import time
 import pathlib
 
-_CAMPAIGNS_DIR = pathlib.Path(
-    __import__("os").environ.get(
-        "OPENTTG_CAMPAIGNS_DIR",
-        str(pathlib.Path.home() / ".local" / "share" / "open-tabletop-gm" / "campaigns")
-    )
-)
+from paths import campaigns_dir as _campaigns_dir
+
+_CAMPAIGNS_DIR = _campaigns_dir()
 
 from datetime import datetime, timezone
 

--- a/scripts/update_skill.py
+++ b/scripts/update_skill.py
@@ -1,0 +1,96 @@
+"""
+update_skill.py — check for and apply updates to the open-tabletop-gm skill from origin/main.
+
+Usage:
+    python3 update_skill.py            # check, show diff, prompt to pull
+    python3 update_skill.py --check    # check only, no pull
+    python3 update_skill.py --yes      # pull without prompting
+
+Refuses to update if the working tree is dirty (protects local patches), and
+uses --ff-only so it never silently merges divergent history.
+
+Skill location is auto-detected as the parent of this script's directory —
+wherever the user cloned the repo. No fixed install path is assumed.
+"""
+import argparse
+import pathlib
+import subprocess
+import sys
+
+SKILL_DIR = pathlib.Path(__file__).resolve().parent.parent
+
+
+def git(*args: str, check: bool = True) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-C", str(SKILL_DIR), *args],
+        capture_output=True, text=True, check=check,
+    )
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--check", action="store_true", help="check only, do not pull")
+    p.add_argument("--yes", action="store_true", help="pull without prompting")
+    args = p.parse_args()
+
+    if not (SKILL_DIR / ".git").exists():
+        print(f"Skill at {SKILL_DIR} is not a git checkout.", file=sys.stderr)
+        print(
+            "Reinstall via: git clone https://github.com/Bobby-Gray/open-tabletop-gm",
+            file=sys.stderr,
+        )
+        return 2
+
+    branch = git("rev-parse", "--abbrev-ref", "HEAD").stdout.strip()
+    print(f"Skill location: {SKILL_DIR}  (branch: {branch})")
+
+    dirty = git("status", "--porcelain").stdout.strip()
+    if dirty:
+        print("Local changes detected — refusing to update:", file=sys.stderr)
+        print(dirty, file=sys.stderr)
+        print("\nCommit, stash, or discard your changes and re-run.", file=sys.stderr)
+        return 3
+
+    git("fetch", "--quiet", "origin", branch)
+    local = git("rev-parse", "HEAD").stdout.strip()
+    remote = git("rev-parse", f"origin/{branch}").stdout.strip()
+
+    if local == remote:
+        print(f"Up to date with origin/{branch} ({local[:7]}).")
+        return 0
+
+    behind = git("rev-list", "--count", f"HEAD..origin/{branch}").stdout.strip()
+    log = git("log", "--oneline", f"HEAD..origin/{branch}").stdout.strip()
+    print(f"Local:  {local[:7]}")
+    print(f"Remote: {remote[:7]}")
+    print(f"\n{behind} commits behind origin/{branch}:")
+    print(log)
+
+    if args.check:
+        return 0
+
+    if not args.yes:
+        try:
+            answer = input("\nPull now? (y/N) ").strip().lower()
+        except EOFError:
+            answer = ""
+        if answer not in {"y", "yes"}:
+            print("Skipped.")
+            return 0
+
+    pull = git("pull", "--ff-only", "origin", branch, check=False)
+    sys.stdout.write(pull.stdout)
+    sys.stderr.write(pull.stderr)
+    if pull.returncode != 0:
+        print(
+            "\nFast-forward failed — resolve manually with git in the skill directory.",
+            file=sys.stderr,
+        )
+        return pull.returncode
+
+    print(f"\nUpdated to {remote[:7]}. Restart your GM session to load new skill files.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Ports two improvements from the upstream claude-dnd-skill repo (issues #12 and #13 there), plus the `paths.py` infrastructure they depend on. Also fixes a latent inconsistency in how this repo resolves the campaign data root.

## Commits

1. **`paths.py` + 5 call-site migrations** — central path resolution with `GM_CAMPAIGN_ROOT` env var (default `~/open-tabletop-gm`).
2. **`/gm path` and `/gm update` commands** — surface skill-management inside the skill itself.

## What this fixes (latent bug)

`scripts/{tracker,calendar,campaign_search}.py` honored an `OPENTTG_CAMPAIGNS_DIR` env var with a default of `~/.local/share/open-tabletop-gm/campaigns/`, but `/gm new`, `gm-display-app.py`, `dm_help.py`, and SKILL.md all use `~/open-tabletop-gm/campaigns/`. The XDG default in those three scripts never matched where campaigns actually got created, so the scripts silently looked in the wrong place for any user who hadn't manually set the env var. Migrating to `paths.py` collapses both roots to a single source of truth.

## New commands

**`/gm path [<new-path> | reset]`** — view or configure where campaign data is stored:

```
$ python3 scripts/path_config.py
Campaign root: ~/open-tabletop-gm  (default — GM_CAMPAIGN_ROOT not set)
  campaigns/   → ~/open-tabletop-gm/campaigns  (3 campaigns)
  characters/  → ~/open-tabletop-gm/characters  (3 characters)
  Tip: /gm path <new-path> to move data (e.g. ~/Dropbox/gm)
```

Persists via shell rc on macOS/Linux and via `setx` on Windows. Existing campaigns are not auto-migrated; `paths.find_campaign()` handles legacy fallback + copy-on-access when a custom root is configured.

**`/gm update [--check]`** — pull latest skill changes from `origin/main`:

- `--ff-only` so divergent history is never silently merged
- Refuses to update if the working tree is dirty (protects local patches)
- Skill location auto-detected via `__file__` (no fixed install path assumed)
- Prompts before pulling unless `--yes` is passed

## Skipped

Nothing relevant — both upstream features ported.

## Deferred

Mobile / non-shell persistence path (a `~/open-tabletop-gm/config.json` so the env var isn't required) — deferred until there's clearer demand.

## Test plan

- [ ] `python3 scripts/path_config.py` prints current root + counts
- [ ] `python3 scripts/path_config.py set ~/Dropbox/gm-test` writes export line to `.zshrc`, reset removes it cleanly
- [ ] `python3 scripts/update_skill.py --check` reports up-to-date or behind without pulling
- [ ] `python3 scripts/update_skill.py` refuses on a dirty tree
- [ ] `from paths import campaigns_dir` works from `scripts/` and from `display/` (via `sys.path` injection)
- [ ] Existing `/gm new`, `/gm load`, `/gm display` flows still work (no regression in path resolution)