### PR TITLE
sync from claude-dnd-skill: NPC rename + name registry + creation hooks

### DIFF
--- a/SKILL-branches.md
+++ b/SKILL-branches.md
@@ -176,10 +176,12 @@ Each turn in combat:
 
 ## `/gm character new`
 
-1. Read `scripts/character.md`
+1. Read `scripts/character.md`. Ask the player for the character's name.
+
+   **Name uniqueness check:** run `python3 <skill-base>/scripts/name_registry.py check "<name>"`. Exit 1 (duplicate) prints which prior campaign / session used the name; surface as a non-blocking warning and ask the player to confirm or change. After write (step 4), call `name_registry.py add --name "<name>" --type pc --campaign <name> --session <current>`.
 2. Follow character creation procedure from `systems/<system>/system.md`
 3. Run `ability-scores.py` and `character.py calc`
-4. Write character file; mirror to global roster
+4. Write character file; mirror to global roster; record name in registry (see step 1)
 
 ---
 

--- a/SKILL-commands.md
+++ b/SKILL-commands.md
@@ -31,7 +31,9 @@ Do NOT run `git init` or any git commands in campaign directories.
 | `/gm characters` | List all characters in the global roster. |
 | `/gm tutor on\|off` | Toggle tutor mode. Write `tutor_mode: true\|false` to state.md. |
 | `/gm display <on\|off> [--lan]` | Start or stop the display companion. Follow `/gm display` branch. Start before `/gm load` if you want it active. |
-| `/gm npc <name>` | Generate or retrieve an NPC. Write to npcs.md / npcs-full.md. |
+| `/gm npc <name>` | Generate or retrieve an NPC. Write to npcs.md / npcs-full.md. **New:** before write, run `name_registry.py check` and surface any prior use; record after write. |
+| `/gm npc rename "Old Name" <"New Name"\|random> [--type pc] [--dry-run] [--yes] [--include-archive]` | Rename a character across npcs.md, npcs-full.md, state.md, session-log.md, world.md, session_tail.json, graph.json (node + edges preserved), and `characters/<slug>.md` if `--type pc`. Backs up the campaign first. `--random` picks from a bundled fantasy-name corpus, rejecting any slug already in the registry. session-log-archive.md left untouched by default + audit note added. Maps to: `python3 <skill-base>/scripts/npc_rename.py --campaign <current> --old "..." --new "..."`. |
+| `/gm registry <subcommand>` | Cross-campaign name registry stored at `<GM_CAMPAIGN_ROOT>/.name_registry.json`. Subcommands: `rebuild [--include-prose]`, `list [--campaign C] [--type] [--source canonical\|prose]`, `lookup <name>`, `check <name> [--json]` (exit 0 unique, 1 duplicate), `add`, `retire`. Maps to `python3 <skill-base>/scripts/name_registry.py <subcommand>`. Severity (`warn`\|`strict`\|`none`) configurable via `<GM_CAMPAIGN_ROOT>/.name_registry_config.json`. |
 | `/gm import <filepath> [campaign-name]` | Import a pre-written campaign source (PDF, MD, DOCX, TXT). See `/gm import` procedure below. |
 | `/gm arc [status\|advance\|revise\|view]` | Manage the dynamic campaign arc. See `/gm arc` procedure below. |
 | `/gm path [<new-path>\|reset]` | View or configure where campaign data is stored (`GM_CAMPAIGN_ROOT`). Follow `/gm path` branch. |

--- a/scripts/name_registry.py
+++ b/scripts/name_registry.py
@@ -1,0 +1,588 @@
+"""
+name_registry.py — persistent cache of every character name ever used
+across all campaigns under this account.
+
+Storage: <GM_CAMPAIGN_ROOT>/.name_registry.json (defaults to
+~/open-tabletop-gm/.name_registry.json).
+
+Purpose:
+    1. Detect duplicate-name proposals at /gm new, /gm character new,
+       /gm npc <new> time (consumed by Piece 2 — uniqueness check).
+    2. Power the random-name path of /gm npc rename (Piece 3) — never
+       pick a name already in the registry.
+    3. Auditable footprint of who's been used where.
+
+Schema per entry (keyed by slug):
+    {
+        "name": "Aldric Voss",
+        "slug": "aldric_voss",
+        "type": "npc" | "pc",
+        "first_campaign": "campaign-name",
+        "first_session": 1,
+        "first_used": "YYYY-MM-DD",
+        "currently_active_in": ["campaign-1", "campaign-2"],
+        "retired_from": [
+            {"campaign": "campaign-name", "replaced_by": "new_slug",
+             "date": "YYYY-MM-DD"}
+        ]
+    }
+
+CLI:
+    python3 name_registry.py rebuild           # scan all campaigns
+    python3 name_registry.py list [--campaign C] [--type npc|pc]
+    python3 name_registry.py lookup <name>     # case-insensitive
+    python3 name_registry.py add --name N --type T --campaign C --session N
+    python3 name_registry.py retire --name N --campaign C [--replaced-by NEW]
+"""
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import pathlib
+import re
+import sys
+
+from paths import campaigns_dir, characters_dir, _root
+
+
+def _registry_path() -> pathlib.Path:
+    return _root() / ".name_registry.json"
+
+
+def _today() -> str:
+    return datetime.date.today().isoformat()
+
+
+def slug(name: str) -> str:
+    """Lowercase, snake_case slug. Drop punctuation; collapse whitespace.
+
+    Strips parenthetical content first so 'Vedra Ceth (V.C.)' and
+    'Vedra Ceth' produce the same slug. Strips trailing/leading whitespace.
+    """
+    s = name.strip().lower()
+    s = re.sub(r"\s*\([^)]*\)\s*", " ", s)  # drop parenthetical asides
+    s = re.sub(r"[^\w\s]", "", s)            # drop remaining punctuation
+    s = re.sub(r"\s+", "_", s).strip("_")    # collapse whitespace to _
+    return s
+
+
+def _load() -> dict:
+    p = _registry_path()
+    if not p.exists():
+        return {"version": 1, "updated": _today(), "entries": {}}
+    try:
+        return json.loads(p.read_text())
+    except json.JSONDecodeError:
+        sys.stderr.write(f"name_registry: {p} is corrupt; starting fresh\n")
+        return {"version": 1, "updated": _today(), "entries": {}}
+
+
+def _save(data: dict) -> None:
+    data["updated"] = _today()
+    p = _registry_path()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(data, indent=2, ensure_ascii=False))
+
+
+# ── Scanners ──────────────────────────────────────────────────────────────
+
+_NPCS_TABLE_ROW = re.compile(r"^\|\s*([^|]+?)\s*\|", re.MULTILINE)
+_NPCS_FULL_HEADER = re.compile(r"^### \s*([^\n]+?)\s*$", re.MULTILINE)
+_NPC_HEADER = re.compile(r"^## \s*([^\n]+?)\s*$", re.MULTILINE)
+_CHARACTER_H1 = re.compile(r"^#\s+([^\n]+?)\s*$", re.MULTILINE)
+_SESSION_COUNT = re.compile(r"\*\*Session count:\*\*\s*(\d+)")
+_LAST_SESSION = re.compile(r"\*\*Last session:\*\*\s*(\d{4}-\d{2}-\d{2})")
+_CREATED = re.compile(r"\*\*Created:\*\*\s*(\d{4}-\d{2}-\d{2})")
+
+
+def _campaign_session_count(camp_dir: pathlib.Path) -> int:
+    state = camp_dir / "state.md"
+    if not state.exists():
+        return 0
+    m = _SESSION_COUNT.search(state.read_text(errors="replace"))
+    return int(m.group(1)) if m else 0
+
+
+def _scan_campaign_npcs(camp_dir: pathlib.Path) -> list[str]:
+    """Read npcs.md table column 1 + npcs-full.md ### headers; return names."""
+    names: list[str] = []
+    npcs = camp_dir / "npcs.md"
+    if npcs.exists():
+        for row in _NPCS_TABLE_ROW.finditer(npcs.read_text(errors="replace")):
+            cell = row.group(1).strip()
+            # Skip header rows ("Name") and divider rows ("---")
+            if not cell or cell.lower() in {"name"} or set(cell) <= {"-", " ", ":"}:
+                continue
+            names.append(cell)
+    full = camp_dir / "npcs-full.md"
+    if full.exists():
+        for h in _NPCS_FULL_HEADER.finditer(full.read_text(errors="replace")):
+            names.append(h.group(1).strip())
+        for h in _NPC_HEADER.finditer(full.read_text(errors="replace")):
+            names.append(h.group(1).strip())
+    return names
+
+
+def _scan_campaign_pcs(camp_dir: pathlib.Path) -> list[str]:
+    """Read characters/*.md H1 line; return PC names."""
+    pcs: list[str] = []
+    char_dir = camp_dir / "characters"
+    if not char_dir.exists():
+        return pcs
+    for f in sorted(char_dir.glob("*.md")):
+        text = f.read_text(errors="replace")
+        m = _CHARACTER_H1.search(text)
+        if m:
+            pcs.append(m.group(1).strip())
+    return pcs
+
+
+def _scan_campaign_graph(camp_dir: pathlib.Path) -> list[tuple[str, str]]:
+    """Read graph.json node names + types — returns [(name, type), ...]."""
+    g = camp_dir / "graph.json"
+    if not g.exists():
+        return []
+    try:
+        data = json.loads(g.read_text())
+    except json.JSONDecodeError:
+        return []
+    out = []
+    for node in data.get("nodes", []):
+        name = node.get("name") or node.get("label")
+        ntype = node.get("type", "npc")
+        # Only collect npc/pc nodes — places/factions/threads aren't characters
+        if name and ntype in {"npc", "pc"}:
+            out.append((name, ntype))
+    return out
+
+
+# ── Operations ────────────────────────────────────────────────────────────
+
+def _ensure_entry(entries: dict, name: str, ntype: str,
+                  campaign: str, session: int) -> dict:
+    s = slug(name)
+    if s in entries:
+        e = entries[s]
+        # Update active list
+        if campaign not in e.get("currently_active_in", []):
+            e.setdefault("currently_active_in", []).append(campaign)
+        return e
+    entries[s] = {
+        "name": name,
+        "slug": s,
+        "type": ntype,
+        "first_campaign": campaign,
+        "first_session": session,
+        "first_used": _today(),
+        "currently_active_in": [campaign],
+        "retired_from": [],
+    }
+    return entries[s]
+
+
+def rebuild() -> dict:
+    """Walk every campaign and populate the registry from scratch.
+
+    Existing retire-from history is preserved on a best-effort basis if
+    the slug matches; otherwise rebuild starts fresh (use --keep-history
+    to preserve all retire records — see CLI flag).
+    """
+    data = _load()
+    old_entries = data.get("entries", {})
+    new_entries: dict = {}
+
+    cd = campaigns_dir()
+    if not cd.exists():
+        return {"campaigns": 0, "entries": 0}
+
+    campaign_count = 0
+    for camp in sorted(cd.iterdir()):
+        if not camp.is_dir() or camp.name.startswith("."):
+            continue
+        if ".backup-" in camp.name:
+            continue
+        campaign_count += 1
+        sess = _campaign_session_count(camp)
+
+        for name in _scan_campaign_npcs(camp):
+            _ensure_entry(new_entries, name, "npc", camp.name, sess)
+        for name in _scan_campaign_pcs(camp):
+            _ensure_entry(new_entries, name, "pc", camp.name, sess)
+        for name, ntype in _scan_campaign_graph(camp):
+            _ensure_entry(new_entries, name, ntype, camp.name, sess)
+
+    # Preserve retire-from history from old registry where slug matches
+    for s, old_e in old_entries.items():
+        if s in new_entries and old_e.get("retired_from"):
+            new_entries[s]["retired_from"] = old_e["retired_from"]
+
+    data["entries"] = new_entries
+    _save(data)
+    return {"campaigns": campaign_count, "entries": len(new_entries)}
+
+
+def add(name: str, ntype: str, campaign: str, session: int) -> dict:
+    data = _load()
+    entry = _ensure_entry(data["entries"], name, ntype, campaign, session)
+    _save(data)
+    return entry
+
+
+def retire(name: str, campaign: str, replaced_by: str | None = None) -> dict | None:
+    data = _load()
+    s = slug(name)
+    if s not in data["entries"]:
+        return None
+    e = data["entries"][s]
+    e["currently_active_in"] = [c for c in e.get("currently_active_in", []) if c != campaign]
+    e.setdefault("retired_from", []).append({
+        "campaign": campaign,
+        "replaced_by": slug(replaced_by) if replaced_by else None,
+        "date": _today(),
+    })
+    _save(data)
+    return e
+
+
+def lookup(name: str) -> dict | None:
+    data = _load()
+    return data["entries"].get(slug(name))
+
+
+def list_entries(campaign: str | None = None,
+                 ntype: str | None = None,
+                 source: str | None = None) -> list[dict]:
+    data = _load()
+    out = []
+    for e in data["entries"].values():
+        if campaign and campaign not in e.get("currently_active_in", []):
+            continue
+        if ntype and e.get("type") != ntype:
+            continue
+        if source and e.get("source", "canonical") != source:
+            continue
+        out.append(e)
+    return sorted(out, key=lambda x: x["name"].lower())
+
+
+def all_taken_slugs() -> set[str]:
+    """Used by random-name path to exclude every name ever seen."""
+    data = _load()
+    return set(data["entries"].keys())
+
+
+def check(name: str) -> dict:
+    """Check whether a proposed name collides with the registry.
+
+    Returns:
+        {
+            "name": str,                # the proposed name (as given)
+            "is_duplicate": bool,
+            "entry": dict | None,       # the existing entry if duplicate
+            "severity": "none" | "warn" | "strict",
+            "message": str,             # human-readable summary
+        }
+
+    Severity is read from `<GM_CAMPAIGN_ROOT>/.name_registry_config.json`
+    (key `severity`); defaults to `"warn"`. `"none"` skips the check entirely
+    (returns is_duplicate=False even when dup); `"warn"` reports but allows;
+    `"strict"` reports and recommends abort.
+    """
+    cfg_path = _root() / ".name_registry_config.json"
+    severity = "warn"
+    if cfg_path.exists():
+        try:
+            cfg = json.loads(cfg_path.read_text())
+            severity = cfg.get("severity", "warn")
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    if severity == "none":
+        return {"name": name, "is_duplicate": False, "entry": None,
+                "severity": severity, "message": "registry check disabled"}
+
+    e = lookup(name)
+    if not e:
+        return {"name": name, "is_duplicate": False, "entry": None,
+                "severity": severity,
+                "message": f"'{name}' is unique — safe to use"}
+
+    where = ", ".join(e.get("currently_active_in", [])) or "(retired everywhere)"
+    src = e.get("source", "canonical")
+    msg = (f"'{name}' was first used in {e['first_campaign']} S{e['first_session']} "
+           f"({src}); currently active in: {where}")
+    return {"name": name, "is_duplicate": True, "entry": e,
+            "severity": severity, "message": msg}
+
+
+# ── Prose scan (--include-prose) ──────────────────────────────────────────
+
+# Match capitalized 2-3 word sequences as candidate proper nouns.
+_PROSE_NAME_PAT = re.compile(r"\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+){1,2})\b")
+
+# Bigram/trigram stopwords — common phrases that look like names but aren't.
+# Add more as you encounter false positives.
+_PROSE_STOP_PHRASES = {
+    "Pale Court", "Muted Order", "Tithe Ledger", "Three Wells",
+    "Marble Stairs", "Ennis Lane", "Coffin Lane", "Carver Lane",
+    "Tannerway Lane", "Felk Lane", "Wick Lane", "Maret Street",
+    "Coppergate Letter", "Speak with Dead", "Detect Magic",
+    "Fog Cloud", "Wild Shape", "Hand of the Tower", "Bell and Hardrock",
+    "Sand Bell", "Hit Dice", "Long Rest", "Short Rest",
+    "Day Six", "Day Seven", "Day Eight", "Lower Archive",
+    "Highward District", "Pillar Quarter", "Ledger Quarter",
+    "Veiled Stair", "Rennick Family", "Greengate", "Veldrath",
+    "Plan A", "Plan B", "Plan C", "Three Names", "Three Truths",
+    "World State", "Faction Moves", "Live State", "Continuity Archive",
+    "Recent Events", "Active Quests", "Open Threads", "Session Flags",
+    "Campaign Arc", "DM Notes", "DM Style", "Pale Court", "Wood Elf",
+    "Circle of Spores", "Hand of the Tower", "Threadbare", "Hierarch Watch",
+    "Hollins", "Erynn Vaude", "Vehn Dral",
+}
+
+# Single-word common-noun starts that masquerade as names — first word
+# patterns to drop entirely.
+_PROSE_STOP_FIRST_WORDS = {
+    "The", "A", "An", "This", "That", "These", "Those",
+    "Day", "Night", "Morning", "Evening", "Bell",
+    "Plan", "Stage", "Phase", "Round", "Turn",
+    "Chapter", "Section", "Step", "Beat", "Act",
+    "Substitution", "Disruption", "Compact",
+}
+
+
+def _scan_prose(camp_dir: pathlib.Path,
+                canonical_first_words: set[str]) -> list[str]:
+    """Return candidate prose-only names from session-log files.
+
+    Filtering layers (each cuts another category of false positives):
+      - exact match against _PROSE_STOP_PHRASES
+      - first word in _PROSE_STOP_FIRST_WORDS (sentence starts, structural)
+      - first word matches a canonical PC's first name (catches "Ben
+        Healing", "Kat Stealth" — skill-check patterns, not NPCs)
+      - second word is a known D&D mechanic / spell / skill word
+        (Healing, Insight, Stealth, Persuasion, Medicine, Wild, Detect,
+        Fog, Speak, Shape, Word, Cure, Mass, etc.)
+      - candidate appears in canonical entries (already known)
+    """
+    canonical_lower = {w.lower() for w in canonical_first_words}
+    candidates: set[str] = set()
+    for fname in ("session-log.md", "session-log-archive.md"):
+        f = camp_dir / fname
+        if not f.exists():
+            continue
+        text = f.read_text(errors="replace")
+        for m in _PROSE_NAME_PAT.finditer(text):
+            cand = m.group(1).strip()
+            if cand in _PROSE_STOP_PHRASES:
+                continue
+            words = cand.split()
+            first, second = words[0], words[1]
+            if first in _PROSE_STOP_FIRST_WORDS:
+                continue
+            # Skip "PC-name + skill/spell/mechanic" patterns
+            if first.lower() in canonical_lower:
+                continue
+            if second in _DND_MECHANIC_WORDS:
+                continue
+            # Skip if any word looks like a roll outcome (digit-suffix)
+            if any(w.endswith(tuple(str(d) for d in range(10))) for w in words):
+                continue
+            candidates.add(cand)
+    return sorted(candidates)
+
+
+# D&D mechanic words that appear capitalized but aren't NPC name parts.
+# Used to filter out "Ben Healing Word", "Kat Stealth", "Ben Medicine 25" etc.
+_DND_MECHANIC_WORDS = {
+    "Healing", "Cure", "Detect", "Speak", "Wild", "Fog", "Mass", "Word",
+    "Bless", "Bane", "Shield", "Hold", "Charm", "Sleep", "Sacred",
+    "Insight", "Stealth", "Persuasion", "Medicine", "Investigation",
+    "Perception", "Arcana", "History", "Religion", "Nature", "Survival",
+    "Athletics", "Acrobatics", "Deception", "Intimidation", "Performance",
+    "Sleight", "Animal", "Initiative", "Stealth", "Fog",
+    "Long", "Short", "Hit", "Spell", "Cantrip", "Action", "Bonus",
+    "Reaction", "Concentration", "Damage", "Saving",
+    "Strength", "Dexterity", "Constitution", "Intelligence", "Wisdom", "Charisma",
+    "STR", "DEX", "CON", "INT", "WIS", "CHA",
+    # Common verbs/nouns that capitalize at sentence start
+    "Briefed", "Cast", "Rolled", "Took", "Asked", "Told", "Said", "Made",
+    "Walked", "Came", "Went", "Got", "Found", "Saw", "Knew", "Heard",
+    "Both", "And", "But", "When", "Then", "Now", "Here", "There",
+    "Bonus", "Crit", "Critical", "Combat", "Round", "Turn",
+}
+
+
+def _canonical_first_words(entries: dict) -> set[str]:
+    """Return first-name set from canonical entries (used to filter prose scan)."""
+    out: set[str] = set()
+    for e in entries.values():
+        if e.get("source", "canonical") != "canonical":
+            continue
+        parts = e["name"].split()
+        if parts:
+            out.add(parts[0])
+    return out
+
+
+def rebuild_with_prose() -> dict:
+    """Like rebuild() but also scans session-log files for likely NPCs.
+
+    Prose-found names are tagged `source: prose` to distinguish from
+    canonical npcs.md / npcs-full.md / characters/ entries (`source:
+    canonical`). When both sources surface the same name, canonical wins.
+    """
+    # Run the normal rebuild first to populate canonical entries
+    canonical_result = rebuild()
+    data = _load()
+    entries = data.get("entries", {})
+
+    # Mark all existing entries as canonical source
+    for e in entries.values():
+        e.setdefault("source", "canonical")
+
+    cd = campaigns_dir()
+    if not cd.exists():
+        return canonical_result
+
+    canonical_first_words = _canonical_first_words(entries)
+    prose_added = 0
+    for camp in sorted(cd.iterdir()):
+        if not camp.is_dir() or camp.name.startswith(".") or ".backup-" in camp.name:
+            continue
+        sess = _campaign_session_count(camp)
+        for cand in _scan_prose(camp, canonical_first_words):
+            s = slug(cand)
+            if not s:
+                continue
+            if s in entries:
+                # Already canonical — record additional active-in but don't downgrade
+                if camp.name not in entries[s].get("currently_active_in", []):
+                    entries[s].setdefault("currently_active_in", []).append(camp.name)
+                continue
+            # New prose-only entry
+            entries[s] = {
+                "name": cand,
+                "slug": s,
+                "type": "npc",
+                "first_campaign": camp.name,
+                "first_session": sess,
+                "first_used": _today(),
+                "currently_active_in": [camp.name],
+                "retired_from": [],
+                "source": "prose",
+            }
+            prose_added += 1
+
+    data["entries"] = entries
+    _save(data)
+    return {"campaigns": canonical_result["campaigns"],
+            "entries": len(entries),
+            "prose_added": prose_added}
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    pb = sub.add_parser("rebuild", help="scan all campaigns, populate registry")
+    pb.add_argument("--include-prose", action="store_true",
+                    help="also scan session-log.md / session-log-archive.md "
+                         "for capitalized name-like sequences (tagged "
+                         "source:prose to distinguish from canonical entries)")
+
+    pl = sub.add_parser("list", help="list registry entries")
+    pl.add_argument("--campaign", help="filter to this campaign's active set")
+    pl.add_argument("--type", choices=["npc", "pc"], help="filter by type")
+    pl.add_argument("--source", choices=["canonical", "prose"],
+                    help="filter by source (canonical = npcs.md/characters/, "
+                         "prose = session-log mentions)")
+
+    pk = sub.add_parser("lookup", help="case-insensitive lookup by name")
+    pk.add_argument("name")
+
+    pc = sub.add_parser("check",
+                        help="check if a proposed name collides with the registry; "
+                             "exit 0 if unique, 1 if duplicate")
+    pc.add_argument("name")
+    pc.add_argument("--json", action="store_true",
+                    help="emit JSON instead of human text")
+
+    pa = sub.add_parser("add", help="record a new name")
+    pa.add_argument("--name", required=True)
+    pa.add_argument("--type", choices=["npc", "pc"], default="npc")
+    pa.add_argument("--campaign", required=True)
+    pa.add_argument("--session", type=int, default=1)
+
+    pr = sub.add_parser("retire", help="mark a name as retired in a campaign")
+    pr.add_argument("--name", required=True)
+    pr.add_argument("--campaign", required=True)
+    pr.add_argument("--replaced-by", help="slug of replacement entry")
+
+    args = p.parse_args()
+
+    if args.cmd == "rebuild":
+        if args.include_prose:
+            result = rebuild_with_prose()
+            print(f"name_registry: scanned {result['campaigns']} campaigns; "
+                  f"{result['entries']} unique names recorded "
+                  f"({result['prose_added']} added from session-log prose scan)")
+        else:
+            result = rebuild()
+            print(f"name_registry: scanned {result['campaigns']} campaigns; "
+                  f"{result['entries']} unique names recorded")
+        print(f"  registry: {_registry_path()}")
+        return 0
+
+    if args.cmd == "list":
+        entries = list_entries(campaign=args.campaign, ntype=args.type,
+                               source=args.source)
+        for e in entries:
+            active = ",".join(e.get("currently_active_in", [])) or "(retired everywhere)"
+            src = e.get("source", "canonical")
+            src_marker = "" if src == "canonical" else f" [{src}]"
+            print(f"  {e['type']:3s}  {e['name']:30s}  first: {e['first_campaign']} S{e['first_session']}  active: {active}{src_marker}")
+        print(f"\n  total: {len(entries)} entries")
+        return 0
+
+    if args.cmd == "lookup":
+        e = lookup(args.name)
+        if not e:
+            print(f"  no entry for '{args.name}'")
+            return 1
+        print(json.dumps(e, indent=2, ensure_ascii=False))
+        return 0
+
+    if args.cmd == "check":
+        result = check(args.name)
+        if args.json:
+            print(json.dumps(result, indent=2, ensure_ascii=False))
+        else:
+            if result["is_duplicate"]:
+                marker = "WARN" if result["severity"] == "warn" else "STRICT"
+                print(f"  [{marker}] DUPLICATE — {result['message']}")
+            else:
+                print(f"  [OK] {result['message']}")
+        return 1 if result["is_duplicate"] else 0
+
+    if args.cmd == "add":
+        e = add(args.name, args.type, args.campaign, args.session)
+        print(json.dumps(e, indent=2, ensure_ascii=False))
+        return 0
+
+    if args.cmd == "retire":
+        e = retire(args.name, args.campaign, args.replaced_by)
+        if not e:
+            print(f"  no entry for '{args.name}'")
+            return 1
+        print(json.dumps(e, indent=2, ensure_ascii=False))
+        return 0
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/npc_rename.py
+++ b/scripts/npc_rename.py
@@ -1,0 +1,444 @@
+"""
+npc_rename.py — rename a character (NPC or PC) across an entire campaign.
+
+Updates every file the name appears in, atomically, with backup-first safety:
+  - npcs.md, npcs-full.md
+  - state.md (every section — Current Situation, Live State Flags, Active
+    Quests, Recent Events, Faction Moves, Continuity Archive, DM Notes)
+  - session-log.md (current sessions)
+  - characters/<slug>.md (renames file too if PC) + global roster mirror
+  - graph.json (renames node by name; edges preserved — they reference IDs)
+
+session-log-archive.md is left untouched by default (historical accuracy)
+unless --include-archive is passed. A one-line audit note is added to the
+archive top noting the rename.
+
+Usage:
+    python3 npc_rename.py --campaign C --old "Old Name" --new "New Name"
+    python3 npc_rename.py --campaign C --old "Old Name" --random
+    python3 npc_rename.py --campaign C --old "Old Name" --new "New" --dry-run
+    python3 npc_rename.py --campaign C --old "Old Name" --new "New" --yes
+    python3 npc_rename.py --campaign C --old "Old Name" --new "New" --type pc
+    python3 npc_rename.py --campaign C --old "Old Name" --new "New" --include-archive
+
+Flags:
+    --dry-run         show hits without writing
+    --yes             skip confirmation prompt
+    --type            npc (default) | pc — pc rename also moves the
+                      character file and updates the global roster
+    --include-archive also rename in session-log-archive.md (default: skip
+                      to preserve historical accuracy; an audit note is
+                      added to the archive top either way)
+"""
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import pathlib
+import random
+import re
+import shutil
+import subprocess
+import sys
+
+from paths import find_campaign, characters_dir, _root
+from name_registry import slug, all_taken_slugs, add as registry_add, retire as registry_retire
+
+
+# ── Embedded fantasy-name corpus ──────────────────────────────────────────
+# 80 first × 60 last = 4800 unique combinations. Sourced from common public-
+# domain fantasy name patterns; no copyrighted material.
+_FIRST = [
+    "Aelric", "Aldon", "Alric", "Anselm", "Arden", "Bael", "Branwen", "Caelum",
+    "Caen", "Cassian", "Cedric", "Corran", "Corvin", "Daric", "Drest", "Eamon",
+    "Elen", "Ember", "Erland", "Eryn", "Fenric", "Galen", "Gareth", "Gennar",
+    "Hadrian", "Halric", "Hartwin", "Idris", "Iren", "Jovan", "Kael", "Kerith",
+    "Lael", "Lirien", "Lorcan", "Lyra", "Maerin", "Mairwen", "Marrick", "Merrin",
+    "Naren", "Nerys", "Niall", "Olen", "Oren", "Perrin", "Quinn", "Rael",
+    "Renwick", "Rhydian", "Rilen", "Rorik", "Saern", "Selwyn", "Senna", "Sevren",
+    "Sorin", "Talin", "Tamsyn", "Theron", "Tiernan", "Tordis", "Trevin", "Ulric",
+    "Valen", "Vellin", "Verra", "Wendel", "Wren", "Xira", "Yael", "Yarrick",
+    "Ysolde", "Zephir", "Auren", "Brel", "Cyrith", "Dorvel", "Fellan", "Hesta",
+]
+
+_LAST = [
+    "Ashbourne", "Bellweather", "Blackmoor", "Brackenhold", "Brightspire", "Carrowfell",
+    "Castermane", "Cinderhold", "Coldspring", "Crowmere", "Dalebrook", "Darkmoor",
+    "Drystone", "Edgewater", "Embervale", "Fairwynd", "Fenlocke", "Fellscarp",
+    "Frostgale", "Glasswain", "Greybarrow", "Hallowind", "Harrowmere", "Hartwell",
+    "Hollowstride", "Innesglen", "Ironholt", "Karnwell", "Larkmere", "Lockmoor",
+    "Marrowfen", "Mistwarden", "Nightbrook", "Oakhaven", "Pellsworth", "Quintain",
+    "Ravenhall", "Reedstrand", "Rookwell", "Sablecroft", "Saltmere", "Silverbrook",
+    "Stormcrest", "Tallowmere", "Thornwell", "Tindalbrook", "Underwich", "Vaelmoor",
+    "Vexworth", "Whitethorn", "Wilderbrook", "Yarrowfield", "Zorrenglade", "Brackleaf",
+    "Coalwarden", "Drosspike", "Greengrave", "Hexmere", "Lampwood", "Pinegate",
+]
+
+
+def random_name(taken_slugs: set[str]) -> str:
+    """Pick first + last from corpus; reject if slug already taken; up to 50 retries.
+
+    Falls back to a numerical suffix if the rare draw exhausts the search.
+    """
+    for _ in range(50):
+        candidate = f"{random.choice(_FIRST)} {random.choice(_LAST)}"
+        if slug(candidate) not in taken_slugs:
+            return candidate
+    # Fallback — suffix with random 3-digit number
+    return f"{random.choice(_FIRST)} {random.choice(_LAST)}-{random.randint(100, 999)}"
+
+
+# ── File-set discovery ────────────────────────────────────────────────────
+
+_TEXT_FILES_ALWAYS = ["npcs.md", "npcs-full.md", "state.md",
+                      "session-log.md", "world.md",
+                      "session_tail.json"]  # display companion's last-N events
+_TEXT_FILES_OPTIONAL = ["session-log-archive.md"]
+
+# Honorific prefixes to strip when computing title-stripped variants.
+# When renaming "Brother Calshen Drey" we ALSO want to match bare
+# "Calshen Drey" references in the same files. Only strips when the
+# remaining tail is ≥ 2 words and ≥ 6 characters (avoids "Brother John"
+# stripping to ambiguous "John").
+_HONORIFICS = {
+    "brother", "sister", "father", "mother", "lord", "lady", "sir", "dame",
+    "captain", "master", "mistress", "miss", "mr", "mr.", "mrs", "mrs.",
+    "ms", "ms.", "dr", "dr.", "king", "queen", "prince", "princess",
+    "duke", "duchess", "count", "countess", "baron", "baroness", "doctor",
+    "professor", "elder", "abbot", "abbess",
+}
+
+
+def _title_stripped(name: str) -> str | None:
+    """Return the name without leading honorific, or None if not eligible.
+
+    Only returns a stripped form when:
+      - first word is in _HONORIFICS
+      - remaining tail has ≥ 2 words AND ≥ 6 characters total
+    """
+    parts = name.strip().split()
+    if len(parts) < 3:
+        return None
+    if parts[0].lower().rstrip(".") not in _HONORIFICS:
+        return None
+    tail = " ".join(parts[1:])
+    if len(tail) < 6:
+        return None
+    return tail
+
+
+def _name_variants(name: str) -> list[str]:
+    """Return all variants of a name to search/replace.
+
+    First the full name, then the title-stripped form if eligible.
+    Order matters — the full form must be replaced first so the stripped
+    form doesn't accidentally swap inside the already-replaced text.
+    """
+    variants = [name]
+    stripped = _title_stripped(name)
+    if stripped:
+        variants.append(stripped)
+    return variants
+
+
+def _files_to_scan(camp_dir: pathlib.Path,
+                   include_archive: bool) -> list[pathlib.Path]:
+    out = []
+    for name in _TEXT_FILES_ALWAYS:
+        f = camp_dir / name
+        if f.exists():
+            out.append(f)
+    if include_archive:
+        for name in _TEXT_FILES_OPTIONAL:
+            f = camp_dir / name
+            if f.exists():
+                out.append(f)
+    return out
+
+
+# ── Hit detection ─────────────────────────────────────────────────────────
+
+def _whole_word_pattern(name: str) -> re.Pattern:
+    """Match the full name as a whole-word sequence; case-sensitive.
+
+    Word-boundary aware so 'Sera' doesn't match inside 'Seraphim' but does
+    match in 'Sera Voss' or 'Sera,'. Multi-word names are joined with a
+    flexible whitespace pattern so 'Aldric  Voss' (double space) still matches.
+    """
+    parts = [re.escape(p) for p in name.strip().split()]
+    body = r"\s+".join(parts)
+    return re.compile(rf"\b{body}\b")
+
+
+def find_hits(camp_dir: pathlib.Path, old: str,
+              include_archive: bool) -> dict[pathlib.Path, list[tuple[int, str]]]:
+    """Scan all relevant files; return {file: [(line_num, line), ...]}.
+
+    Searches both the full name AND the title-stripped variant (e.g.
+    'Calshen Drey' for 'Brother Calshen Drey'). Each hit line is reported
+    once even if both variants match it.
+    """
+    variants = _name_variants(old)
+    patterns = [_whole_word_pattern(v) for v in variants]
+    hits: dict[pathlib.Path, list[tuple[int, str]]] = {}
+    for f in _files_to_scan(camp_dir, include_archive):
+        try:
+            text = f.read_text(errors="replace")
+        except OSError:
+            continue
+        matches: list[tuple[int, str]] = []
+        seen_lines: set[int] = set()
+        for n, line in enumerate(text.splitlines(), start=1):
+            if any(p.search(line) for p in patterns) and n not in seen_lines:
+                matches.append((n, line.rstrip()))
+                seen_lines.add(n)
+        if matches:
+            hits[f] = matches
+    return hits
+
+
+# ── Apply ─────────────────────────────────────────────────────────────────
+
+def apply_text_rename(path: pathlib.Path, old: str, new: str) -> int:
+    """Replace each variant of `old` with the corresponding variant of `new`.
+
+    Variant pairing:
+      - full(old) → full(new)
+      - stripped(old) → stripped(new) if stripped(new) exists, else full(new)
+
+    Order: full first (longest match wins), then stripped — so we don't
+    accidentally double-replace inside an already-substituted string.
+    Returns total replacement count across all variants.
+    """
+    text = path.read_text(errors="replace")
+    total = 0
+
+    old_full = old
+    new_full = new
+    pat_full = _whole_word_pattern(old_full)
+    text, n = pat_full.subn(new_full, text)
+    total += n
+
+    old_stripped = _title_stripped(old)
+    if old_stripped:
+        new_stripped = _title_stripped(new) or new_full
+        pat_stripped = _whole_word_pattern(old_stripped)
+        text, n = pat_stripped.subn(new_stripped, text)
+        total += n
+
+    if total > 0:
+        path.write_text(text)
+    return total
+
+
+def apply_graph_rename(graph_path: pathlib.Path, old: str, new: str) -> bool:
+    """Rename node whose .name == old → new. Edges reference node IDs so
+    they're untouched. Also rewrites the slug-prefixed node id if present.
+
+    Returns True if a node was renamed.
+    """
+    if not graph_path.exists():
+        return False
+    try:
+        data = json.loads(graph_path.read_text())
+    except json.JSONDecodeError:
+        return False
+    old_slug = slug(old)
+    new_slug = slug(new)
+    renamed = False
+    nodes = data.get("nodes", [])
+    id_remap: dict[str, str] = {}
+    for node in nodes:
+        if node.get("name") == old:
+            node["name"] = new
+            # Remap node id if it follows the type_slug convention
+            old_id = node.get("id", "")
+            ntype = node.get("type", "npc")
+            expected_old_id = f"{ntype}_{old_slug}"
+            if old_id == expected_old_id:
+                new_id = f"{ntype}_{new_slug}"
+                node["id"] = new_id
+                id_remap[old_id] = new_id
+            renamed = True
+    # Rewrite edges that reference renamed node ids
+    for edge in data.get("edges", []):
+        for k in ("from", "to"):
+            if edge.get(k) in id_remap:
+                edge[k] = id_remap[edge[k]]
+    if renamed:
+        graph_path.write_text(json.dumps(data, indent=2, ensure_ascii=False))
+    return renamed
+
+
+def add_archive_audit_note(camp_dir: pathlib.Path, old: str, new: str,
+                           session: int) -> bool:
+    """Add a one-line audit note at the top of session-log-archive.md."""
+    archive = camp_dir / "session-log-archive.md"
+    if not archive.exists():
+        return False
+    text = archive.read_text(errors="replace")
+    today = datetime.date.today().isoformat()
+    note = (f"<!-- rename audit {today}: '{old}' renamed to '{new}' "
+            f"at S{session}; historical entries below preserve the original name -->\n")
+    if note.split(": ", 1)[1].split(" at S")[0] in text:
+        # Already noted — don't double-note
+        return False
+    archive.write_text(note + text)
+    return True
+
+
+# ── Main flow ─────────────────────────────────────────────────────────────
+
+def _read_session_count(camp_dir: pathlib.Path) -> int:
+    state = camp_dir / "state.md"
+    if not state.exists():
+        return 0
+    m = re.search(r"\*\*Session count:\*\*\s*(\d+)",
+                  state.read_text(errors="replace"))
+    return int(m.group(1)) if m else 0
+
+
+def _backup(camp_dir: pathlib.Path) -> pathlib.Path:
+    ts = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+    target = camp_dir.with_name(f"{camp_dir.name}.backup-rename-{ts}")
+    shutil.copytree(camp_dir, target)
+    return target
+
+
+def _confirm(prompt: str) -> bool:
+    try:
+        ans = input(prompt + " [y/n] ").strip().lower()
+    except EOFError:
+        return False
+    return ans in {"y", "yes"}
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--campaign", required=True)
+    p.add_argument("--old", required=True, help="existing character name")
+    grp = p.add_mutually_exclusive_group(required=True)
+    grp.add_argument("--new", help="explicit new name")
+    grp.add_argument("--random", action="store_true",
+                     help="pick a registry-safe random name")
+    p.add_argument("--type", choices=["npc", "pc"], default="npc")
+    p.add_argument("--dry-run", action="store_true",
+                   help="show hits without writing")
+    p.add_argument("--yes", action="store_true",
+                   help="skip confirmation prompt")
+    p.add_argument("--include-archive", action="store_true",
+                   help="also rename in session-log-archive.md "
+                        "(default: leave historical text intact)")
+
+    args = p.parse_args()
+
+    camp_dir = find_campaign(args.campaign)
+    if not camp_dir.exists():
+        print(f"npc_rename: campaign '{args.campaign}' not found at {camp_dir}",
+              file=sys.stderr)
+        return 1
+
+    # Resolve --new (explicit or random)
+    if args.random:
+        taken = all_taken_slugs()
+        new_name = random_name(taken)
+        print(f"  --random picked: {new_name}")
+    else:
+        new_name = args.new
+
+    # Find hits
+    hits = find_hits(camp_dir, args.old, args.include_archive)
+    if not hits:
+        print(f"npc_rename: no occurrences of '{args.old}' found in {camp_dir.name}",
+              file=sys.stderr)
+        return 1
+
+    total_lines = sum(len(v) for v in hits.values())
+    print(f"\n=== rename plan: '{args.old}' → '{new_name}' in {camp_dir.name} ===")
+    print(f"  files affected : {len(hits)}")
+    print(f"  total matches  : {total_lines}\n")
+    for f, matches in hits.items():
+        print(f"  {f.name}: {len(matches)} matches")
+        for ln, line in matches[:3]:
+            preview = line if len(line) <= 120 else line[:117] + "..."
+            print(f"    L{ln}: {preview}")
+        if len(matches) > 3:
+            print(f"    ... and {len(matches) - 3} more")
+    # Graph rename preview
+    g = camp_dir / "graph.json"
+    if g.exists():
+        try:
+            data = json.loads(g.read_text())
+            graph_match = any(n.get("name") == args.old for n in data.get("nodes", []))
+            if graph_match:
+                print(f"  graph.json: 1 node will be renamed (edges preserved)")
+        except json.JSONDecodeError:
+            pass
+    # PC file rename preview
+    if args.type == "pc":
+        old_pc = camp_dir / "characters" / f"{slug(args.old)}.md"
+        if old_pc.exists():
+            print(f"  characters/{slug(args.old)}.md → characters/{slug(new_name)}.md")
+            print(f"  WARNING: PC rename also updates global roster at "
+                  f"{characters_dir() / (slug(args.old) + '.md')}")
+
+    if args.dry_run:
+        print("\n  --dry-run set; no writes performed.")
+        return 0
+
+    if not args.yes:
+        if not _confirm("\nApply rename (with backup)?"):
+            print("  cancelled.")
+            return 1
+
+    # Backup
+    backup = _backup(camp_dir)
+    print(f"\n  backup: {backup}")
+
+    # Apply text renames
+    total_replacements = 0
+    for f in list(hits.keys()):
+        n = apply_text_rename(f, args.old, new_name)
+        print(f"    {f.name}: {n} replacements")
+        total_replacements += n
+
+    # Apply graph rename
+    if g.exists():
+        if apply_graph_rename(g, args.old, new_name):
+            print(f"    graph.json: node renamed")
+
+    # PC file rename
+    if args.type == "pc":
+        old_pc = camp_dir / "characters" / f"{slug(args.old)}.md"
+        if old_pc.exists():
+            new_pc = camp_dir / "characters" / f"{slug(new_name)}.md"
+            old_pc.rename(new_pc)
+            print(f"    characters/{slug(args.old)}.md → characters/{slug(new_name)}.md")
+            # Mirror to global roster
+            global_old = characters_dir() / f"{slug(args.old)}.md"
+            global_new = characters_dir() / f"{slug(new_name)}.md"
+            if global_old.exists():
+                shutil.copy(new_pc, global_new)
+                global_old.unlink()
+                print(f"    global roster updated")
+
+    # Archive audit note (only if NOT including archive in rename)
+    if not args.include_archive:
+        sess = _read_session_count(camp_dir)
+        if add_archive_audit_note(camp_dir, args.old, new_name, sess):
+            print(f"    session-log-archive.md: audit note added at top")
+
+    # Update name registry
+    sess = _read_session_count(camp_dir)
+    registry_retire(args.old, args.campaign, replaced_by=new_name)
+    registry_add(new_name, args.type, args.campaign, sess)
+    print(f"    name_registry: '{args.old}' retired, '{new_name}' added")
+
+    print(f"\n  done. {total_replacements} text replacements + graph + registry updates.")
+    print(f"  To revert: rm -rf '{camp_dir}' && mv '{backup}' '{camp_dir}'")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Forward-syncs claude-dnd-skill PRs #26 + #27 into open-tabletop-gm.

**scripts/name_registry.py** — persistent cache of every canonical character name across all campaigns. Stored at `<GM_CAMPAIGN_ROOT>/.name_registry.json`. Subcommands: `rebuild [--include-prose]`, `list [--campaign C] [--type] [--source canonical|prose]`, `lookup`, `check NAME [--json]` (exit 0 unique / 1 duplicate), `add`, `retire`. Severity (warn|strict|none) configurable via `.name_registry_config.json`.

**scripts/npc_rename.py** — rename a character across an entire campaign atomically with backup-first safety:
- `npcs.md`, `npcs-full.md`, `state.md`, `session-log.md`, `world.md`, `session_tail.json`, `graph.json` (node + edges preserved)
- `characters/<slug>.md` if `--type pc` + global roster mirror
- `session-log-archive.md` left untouched by default + audit note
- `--random` picks from bundled fantasy-name corpus (~4800 combinations) rejecting any slug already in the registry
- Title-stripped matching: 'Brother Calshen Drey' also matches bare 'Calshen Drey'

**SKILL-branches.md** — `/gm character new` step 1: name uniqueness check + record after write.
**SKILL-commands.md** — command table documents `/gm npc rename` + `/gm registry` subcommands.

System-agnostic — no D&D mechanics. Terminology preserved.