### PR TITLE
probe(persistence_v2): multi-turn story-persistence battery

### DIFF
--- a/probe/persistence_v2/README.md
+++ b/probe/persistence_v2/README.md
@@ -1,0 +1,122 @@
+# persistence_v2 — multi-turn story-persistence probe
+
+A methodologically rigorous probe that measures whether a model **remembers** what the bible established, across a 20-turn conversation. Differs from the original `narrative_probe.py` (single-turn × 12 scenarios) by holding state across turns the way a real play session does.
+
+This probe was originally built for [Neural Initiative](https://github.com/Bobby-Gray/neuralinitiative) — the SaaS sibling of `open-tabletop-gm` — and ported here in cleaned-up form so the open-source community can run the same evaluation against any OpenRouter-routable model.
+
+## What it actually measures
+
+For each model, the probe runs the same scripted player path through three **distinct** campaign bibles (medieval fantasy, sci-fi, modern horror). Each bible introduces facts at specific turns (NPC traits, scene anchors, player choices) and tests recall of those facts 6-15 turns later.
+
+**Persistence index** is the fraction of recall tests the model passes. A recall test is "did the model demonstrate it remembers this fact" — judged by a separate cheap LLM (not regex matching).
+
+The probe reports:
+- **Persistence (unweighted)** — fraction of all recall tests passed
+- **Weighted persistence** — same, but each test is weighted by `sqrt(turn distance from seed)` so long-range recall dominates. This is what we actually care about; immediate recall is trivial.
+
+## Why we replaced regex with LLM-judged recall
+
+The original regex approach has two systematic failure modes:
+
+| Failure | Example |
+|---|---|
+| **False positive** | Pattern `\btense\b` matches the room atmosphere being described as tense, not the NPC the test cares about. Probe credits the model with recall it didn't actually do. |
+| **False negative** | Model says "the boy" — character-consistent voice for a young NPC named Aldric — but the regex needed `\baldric\b` literal. Probe penalizes correct paraphrase. |
+
+Asking a small LLM "did this response demonstrate knowledge of fact X?" sidesteps both. Judge calibration cases live in `judge.py` so anyone porting can validate their judge stays honest.
+
+## Calibration modes (the methodological backbone)
+
+Without baselines, a "65% persistence" number floats. The probe runs each (model × bible) combination in **four modes** so every score lands in a known measurement range:
+
+| Mode | What it tests | Use |
+|---|---|---|
+| **naive** | Fresh request per turn, no conversation history at all. Just `system_prompt + current_action`. | Floor. Tells you what the model can do with bible-only context. |
+| **normal** | System prompt + full conversation history. Current production behavior. | The number you actually care about. |
+| **scaffolded** | normal + a compact `<reminders>` block prepended to every player action. The reminders list active NPCs with their key traits, parsed from the bible. | Tests whether per-turn re-injection of canon facts closes the gap. |
+| **perfect** | normal + the FULL bible re-prepended to every player action. | Ceiling. Tells you what the model can do if attention to canon is forced. |
+
+Reading the modes together:
+- If naive ≈ normal, the model isn't using conversation history (bad)
+- If normal ≈ perfect, attention to canon is the bottleneck (scaffolding will help)
+- If scaffolded > normal substantially, ship scaffolding for that model in production
+- If scaffolded < normal, the reminders are distracting (turn scaffolding OFF for that model)
+
+That last case is real — when this probe was first run, adding scaffolding **hurt** Sonnet's persistence by ~10pt because the explicit reminder block competed with Sonnet's already-strong native attention to the bible. The same scaffolding helped Gemini ~+11pt. Per-model decisions matter; one-size-fits-all prompt scaffolding is wrong.
+
+## The three bibles
+
+Bibles are sized identically (5 NPCs, 2 factions, 20 turns, 7 recall tests) so the persistence index is comparable across them. Three genres so we can detect a model whose recall is good only in its training-distribution sweet spot:
+
+- **valdremor** — medieval fantasy (urban ruined-empire setting; rogue protagonist)
+- **atrias** — sci-fi (orbiting beanstalk skyport; forensic-accountant fixer)
+- **nightshift** — modern horror (Ohio rust-belt town, 2am; crime reporter)
+
+## Running
+
+Requires Python 3.11+ and an OpenRouter API key.
+
+```bash
+# Smoke test (1 model, 1 bible, 1 mode, 1 trial — ~3 minutes)
+export OPENROUTER_API_KEY=sk-or-v1-...
+python -m probe.persistence_v2 \
+  --subjects anthropic/claude-sonnet-4-6 \
+  --bibles valdremor \
+  --modes normal \
+  --trials 1 \
+  --out-dir results/smoke
+
+# Full battery (4 models × 3 bibles × 4 modes × 2 trials — ~45-60 minutes)
+python -m probe.persistence_v2 \
+  --subjects anthropic/claude-sonnet-4-6,anthropic/claude-haiku-4-5,openai/gpt-4o,google/gemini-2.5-pro \
+  --bibles valdremor,atrias,nightshift \
+  --modes naive,normal,scaffolded,perfect \
+  --trials 2 \
+  --out-dir results/v2_full
+```
+
+Outputs:
+- `results/.../{subject}__{bible}__{mode}__t{trial}.json` — full turn-by-turn record + every judge call's reasoning
+- `results/.../rollup.json` — aggregated cell + per-subject-mode tables
+- `results/.../rollup.md` — human-readable summary
+
+## Aggregation
+
+For each (subject, bible, mode) cell, the probe reports `mean ± pstdev` across trials. If `pstdev` is high relative to the gap you care about, run more trials.
+
+The recommended top-line for cross-model comparisons is **weighted persistence in normal mode, averaged across all three bibles**. That number is what production users actually experience.
+
+## Adding a new bible
+
+1. Drop a file in `bibles/` following the shape in `bibles/valdremor.py`:
+   - `BIBLE` (str) — setting + recent events + factions + current scene
+   - `NPCS` (str) — 5 NPCs in `### Name` markdown with at minimum `**Demeanor:**` and `**Speech quirk:**` lines (the scaffolding parser keys on these)
+   - `FACTS` (tuple of `Fact`) — discrete bible-canon items the recall tests probe
+   - `TURNS` (tuple of `Turn`) — 20 player actions, annotated with `seed` / `neutral` / `recall` kind + `targets` listing fact ids
+2. Register it in `bibles/__init__.py::BIBLES`.
+
+The structural shape — when facts seed, when they're recalled, how many recall tests — should match the existing bibles so the persistence index stays comparable across them.
+
+## Adding a new judge
+
+`judge.py::judge_recall` accepts any OpenRouter route. The default is `google/gemini-2.5-flash` (cheap, fast, semantically sharp). To swap, set `PROBE_JUDGE_MODEL`:
+
+```bash
+PROBE_JUDGE_MODEL="anthropic/claude-haiku-4-5" python -m probe.persistence_v2 ...
+```
+
+The judge's calibration cases in `judge.py::CALIBRATION_CASES` should pass against any reasonable swap. Run them first:
+
+```bash
+python -m probe.persistence_v2.calibrate
+```
+
+## Known limitations
+
+- **Scripted player path.** Real chat-level usage is reactive; here actions are pre-written. A `v3` would make actions react to the model's prior turn, closer to actual usage. Larger structural change.
+- **Single-judge bias.** One LLM judges all responses. Systematic judge bias affects all subjects equally, but it's still bias. An N-judge ensemble (3-5 models, inter-rater agreement reported) would close this.
+- **Quality vs persistence.** This probe measures memory, not prose quality. A model can ace persistence while writing wooden prose, or vice versa. The original `narrative_probe.py` covers atmosphere / npc_craft / gm_craft separately; run both for a complete picture.
+
+## Provenance
+
+Originally built for [Neural Initiative](https://github.com/Bobby-Gray/neuralinitiative); methodology and code refined in [this analysis doc](https://github.com/Bobby-Gray/neuralinitiative/blob/main/docs/probes/sonnet_vs_gemini_2026-06-10.md). Ported here under the AGPL-3.0-or-later license that covers the rest of `open-tabletop-gm`.

--- a/probe/persistence_v2/README.md
+++ b/probe/persistence_v2/README.md
@@ -2,7 +2,7 @@
 
 A methodologically rigorous probe that measures whether a model **remembers** what the bible established, across a 20-turn conversation. Differs from the original `narrative_probe.py` (single-turn × 12 scenarios) by holding state across turns the way a real play session does.
 
-This probe was originally built for [Neural Initiative](https://github.com/Bobby-Gray/neuralinitiative) — the SaaS sibling of `open-tabletop-gm` — and ported here in cleaned-up form so the open-source community can run the same evaluation against any OpenRouter-routable model.
+Built for `open-tabletop-gm` users + anyone who wants to know which model their preferred GM stack should run on. Pairs naturally with `narrative_probe.py` (atmosphere / npc_craft / gm_craft scoring) — the two probes measure different things and a complete model evaluation runs both.
 
 ## What it actually measures
 
@@ -117,6 +117,6 @@ python -m probe.persistence_v2.calibrate
 - **Single-judge bias.** One LLM judges all responses. Systematic judge bias affects all subjects equally, but it's still bias. An N-judge ensemble (3-5 models, inter-rater agreement reported) would close this.
 - **Quality vs persistence.** This probe measures memory, not prose quality. A model can ace persistence while writing wooden prose, or vice versa. The original `narrative_probe.py` covers atmosphere / npc_craft / gm_craft separately; run both for a complete picture.
 
-## Provenance
+## License
 
-Originally built for [Neural Initiative](https://github.com/Bobby-Gray/neuralinitiative); methodology and code refined in [this analysis doc](https://github.com/Bobby-Gray/neuralinitiative/blob/main/docs/probes/sonnet_vs_gemini_2026-06-10.md). Ported here under the AGPL-3.0-or-later license that covers the rest of `open-tabletop-gm`.
+AGPL-3.0-or-later, same as the rest of `open-tabletop-gm`.

--- a/probe/persistence_v2/__main__.py
+++ b/probe/persistence_v2/__main__.py
@@ -1,0 +1,78 @@
+"""Entry point: python -m probe.persistence_v2 ...
+
+Smoke test:
+  python -m probe.persistence_v2 \\
+    --subjects anthropic/claude-sonnet-4-6 \\
+    --bibles valdremor \\
+    --modes normal \\
+    --trials 1
+
+Full battery (4 models × 3 bibles × 4 modes × 2 trials):
+  python -m probe.persistence_v2 \\
+    --subjects anthropic/claude-sonnet-4-6,anthropic/claude-haiku-4-5,openai/gpt-4o,google/gemini-2.5-pro \\
+    --bibles valdremor,atrias,nightshift \\
+    --modes naive,normal,scaffolded,perfect \\
+    --trials 2
+
+Requires $OPENROUTER_API_KEY.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+from .runner import aggregate, run_battery, write_report_md
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--subjects", required=True,
+                   help="Comma-separated OpenRouter routes (e.g. anthropic/claude-sonnet-4-6)")
+    p.add_argument("--bibles", default="valdremor,atrias,nightshift",
+                   help="Comma-separated bible names")
+    p.add_argument("--modes", default="normal,scaffolded",
+                   help="Comma-separated: naive,normal,scaffolded,perfect")
+    p.add_argument("--trials", type=int, default=2)
+    p.add_argument("--concurrency", type=int, default=4)
+    p.add_argument("--out-dir", default="probe/persistence_v2/results")
+    args = p.parse_args()
+
+    api_key = os.environ.get("OPENROUTER_API_KEY", "").strip()
+    if not api_key:
+        print("ERROR: set OPENROUTER_API_KEY in env", file=sys.stderr)
+        return 1
+
+    subjects = [s.strip() for s in args.subjects.split(",") if s.strip()]
+    bibles = [b.strip() for b in args.bibles.split(",") if b.strip()]
+    modes = [m.strip() for m in args.modes.split(",") if m.strip()]
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    total = len(subjects) * len(bibles) * len(modes) * args.trials
+    print(f"Planned: {total} trials "
+          f"({len(subjects)} subjects × {len(bibles)} bibles × "
+          f"{len(modes)} modes × {args.trials} trials)",
+          file=sys.stderr)
+    print(f"Concurrency cap: {args.concurrency}", file=sys.stderr)
+    print(f"Out dir: {out_dir}", file=sys.stderr)
+
+    results = asyncio.run(run_battery(
+        subject_routes=subjects, bible_names=bibles, modes=modes,
+        trials=args.trials, api_key=api_key,
+        concurrency=args.concurrency, out_dir=out_dir,
+    ))
+    print(f"Completed {len(results)}/{total} trials", file=sys.stderr)
+
+    rollup = aggregate(results)
+    (out_dir / "rollup.json").write_text(json.dumps(rollup, indent=2))
+    write_report_md(rollup, out_dir / "rollup.md", label="persistence_v2")
+    print(f"\nRollup: {out_dir / 'rollup.md'}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/probe/persistence_v2/__main__.py
+++ b/probe/persistence_v2/__main__.py
@@ -39,7 +39,15 @@ def main() -> int:
     p.add_argument("--trials", type=int, default=2)
     p.add_argument("--concurrency", type=int, default=4)
     p.add_argument("--out-dir", default="probe/persistence_v2/results")
+    p.add_argument("--judges", default="",
+                   help="Comma-separated OpenRouter judge routes. "
+                        "Empty = use DEFAULT_JUDGE_MODELS (5-judge ensemble).")
     args = p.parse_args()
+    from .judge import DEFAULT_JUDGE_MODELS
+    judge_models = (
+        [j.strip() for j in args.judges.split(",") if j.strip()]
+        if args.judges else DEFAULT_JUDGE_MODELS
+    )
 
     api_key = os.environ.get("OPENROUTER_API_KEY", "").strip()
     if not api_key:
@@ -60,14 +68,18 @@ def main() -> int:
     print(f"Concurrency cap: {args.concurrency}", file=sys.stderr)
     print(f"Out dir: {out_dir}", file=sys.stderr)
 
+    print(f"Judge ensemble ({len(judge_models)}): "
+          f"{', '.join(j.split('/')[-1] for j in judge_models)}",
+          file=sys.stderr)
     results = asyncio.run(run_battery(
         subject_routes=subjects, bible_names=bibles, modes=modes,
         trials=args.trials, api_key=api_key,
+        judge_models=judge_models,
         concurrency=args.concurrency, out_dir=out_dir,
     ))
     print(f"Completed {len(results)}/{total} trials", file=sys.stderr)
 
-    rollup = aggregate(results)
+    rollup = aggregate(results, judge_models=judge_models)
     (out_dir / "rollup.json").write_text(json.dumps(rollup, indent=2))
     write_report_md(rollup, out_dir / "rollup.md", label="persistence_v2")
     print(f"\nRollup: {out_dir / 'rollup.md'}", file=sys.stderr)

--- a/probe/persistence_v2/bibles/__init__.py
+++ b/probe/persistence_v2/bibles/__init__.py
@@ -1,0 +1,78 @@
+"""Bible registry.
+
+Each module in this package defines BIBLE, NPCS, FACTS, TURNS at
+module top-level. Re-exported here as a single dict so the runner can
+look them up by name.
+
+Adding a new bible:
+  1. Drop a file `bibles/<name>.py` following the shape of valdremor.py
+  2. Add the import + entry below
+  3. The runner picks it up automatically via the BIBLES dict
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from . import atrias, nightshift, valdremor
+
+
+TurnKind = Literal["seed", "neutral", "recall"]
+
+
+@dataclass(frozen=True)
+class Turn:
+    idx: int
+    action: str
+    kind: TurnKind
+    seeds: tuple[str, ...] = ()
+    targets: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class Fact:
+    id: str
+    description: str
+
+
+@dataclass(frozen=True)
+class Bible:
+    name: str
+    genre: str
+    system_prompt: str
+    npcs_md: str
+    facts: tuple[Fact, ...]
+    turns: tuple[Turn, ...]
+
+
+def _build(mod, name: str, genre: str) -> Bible:
+    return Bible(
+        name=name,
+        genre=genre,
+        system_prompt=mod.BIBLE + "\n\n" + mod.NPCS,
+        npcs_md=mod.NPCS,
+        facts=tuple(Fact(id=f.id, description=f.description) for f in mod.FACTS),
+        turns=tuple(
+            Turn(idx=t.idx, action=t.action, kind=t.kind,
+                 seeds=t.seeds, targets=t.targets)
+            for t in mod.TURNS
+        ),
+    )
+
+
+BIBLES: dict[str, Bible] = {
+    "valdremor":  _build(valdremor,  "valdremor",  "medieval fantasy"),
+    "atrias":     _build(atrias,     "atrias",     "sci-fi"),
+    "nightshift": _build(nightshift, "nightshift", "modern horror"),
+}
+
+
+def fact_by_id(bible: Bible, fact_id: str):
+    return next((f for f in bible.facts if f.id == fact_id), None)
+
+
+def seed_turn_for_fact(bible: Bible, fact_id: str) -> int | None:
+    for t in bible.turns:
+        if fact_id in t.seeds:
+            return t.idx
+    return None

--- a/probe/persistence_v2/bibles/atrias.py
+++ b/probe/persistence_v2/bibles/atrias.py
@@ -1,0 +1,94 @@
+"""Atrias — sci-fi orbital-station bible + 20-turn script.
+
+A beanstalk skyport above a dead colony world. Player is a forensic
+accountant turned fixer who may have killed someone on her last job;
+recall tests probe whether the model carries that thread.
+"""
+from __future__ import annotations
+
+from .valdremor import Turn, Fact  # reuse same dataclasses
+
+
+BIBLE = """## Campaign: The Atrias Loop
+
+**Setting:** Atrias Station — a beanstalk skyport orbiting a dead colony world. The station is the last legal port for the Outer Loop; smugglers and corp courier ships dock side by side. Climate-controlled habitat rings rotate slowly; gravity is 0.3g on the docks, 1g in the core. The station's water plant is failing and the corp that owns it is gouging on rations.
+
+**Player character:** Vex, a former corporate forensic accountant who quit when she discovered the water price-rigging scheme. She freelances as a fixer now — small jobs, no questions. Dry, methodical, distrustful of authority.
+
+**Recent events:** Two cycles ago, Vex accepted a job from Yulen (Loop-side data broker) to extract a corp executive's personal logs. She got the logs, but in the process she destabilized a maintenance drone that may have killed a junior engineer named Rell. She doesn't know yet if Rell survived. She left fast.
+
+**Factions:**
+- **Helion Holdings** — the corp that owns the water plant. Tregaard's faction.
+- **Loop Hands** — the Outer Loop smugglers' loose coalition. Yulen's faction.
+
+**Current scene:** Vex is at a noodle stand on Habitat Ring 3 — open-air vendor strip with hissing protein presses, fluorescent panel light, the constant low whine of the station's ventilation.
+"""
+
+NPCS = """### Yulen
+**Role:** Loop-side data broker, gave Vex the corp logs job
+**Demeanor:** Tall, thin, prosthetic right arm with a sticking elbow servo. Cautious about debts.
+**Speech quirk:** Rounds every price up to a number ending in 7.
+
+### Rell
+**Role:** Junior engineer Vex's job may have killed
+**Demeanor:** Young, eager, off-station hair (still long, not station-shaved). Owes Vex nothing — Vex owes Rell everything.
+**Speech quirk:** Stammers when contradicted.
+
+### Tregaard
+**Role:** Helion Holdings water-plant director, target of Vex's prior extraction
+**Demeanor:** Heavy, calm, salt-and-pepper close-crop, lab-coat clean.
+**Speech quirk:** Never raises his voice.
+
+### Mei (noodle vendor)
+**Role:** Ring 3 vendor who knows everyone passing through
+**Demeanor:** Older, missing two fingers on her left hand from a press accident. Eyes for trouble.
+**Speech quirk:** Calls strangers "kid."
+
+### Anso
+**Role:** Helion station security captain
+**Demeanor:** Heavyset, magnetic boots scuffed, dislikes Loop-side traders.
+**Speech quirk:** Quotes the Station Compact word-for-word.
+"""
+
+FACTS = (
+    Fact("mei_fingers", "Mei is missing two fingers on her left hand (press accident)"),
+    Fact("mei_kid", "Mei calls strangers 'kid'"),
+    Fact("rell_eager", "Rell is young, eager, with long off-station hair; Vex owes Rell after a past job"),
+    Fact("tregaard_quiet", "Tregaard never raises his voice; he is heavy, calm, lab-coat clean"),
+    Fact("tregaard_target", "Tregaard was the target of Vex's prior extraction job"),
+    Fact("yulen_arm", "Yulen has a prosthetic right arm with a sticking elbow servo"),
+    Fact("yulen_seven", "Yulen rounds every price up to a number ending in 7"),
+    Fact("rell_jeopardy", "Vex's prior job may have killed Rell (open thread, unresolved)"),
+)
+
+TURNS = (
+    Turn(1,  "I scan Ring 3 for tails before approaching any vendor.", "neutral"),
+    Turn(2,  "I drift toward Mei's noodle stand. I order a bowl and tip enough that she'll talk.", "seed",
+         seeds=("mei_fingers", "mei_kid")),
+    Turn(3,  "I ask her if she's heard about anyone Helion is looking for this week.", "neutral"),
+    Turn(4,  "I read her response. If she's hedging, I push back gently. If she's clean, I move on.", "neutral"),
+    Turn(5,  "I leave Ring 3 and head to the Lower Cargo Spine. Gravity drops to 0.3g as I go.", "neutral"),
+    Turn(6,  "I should find out if Rell is alive. I head to the junior crew berths and wait near them, off-camera.", "seed",
+         seeds=("rell_jeopardy",)),
+    Turn(7,  "I wait until shift change. I follow one of the engineers heading off-shift at a distance.", "neutral"),
+    Turn(8,  "I catch up to her in a maintenance corridor and step out. 'Looking for Rell.' How does she react?", "recall",
+         targets=("rell_eager", "rell_jeopardy")),
+    Turn(9,  "I ask if Rell came back from the incident two cycles ago. I make it clear I'm not Helion.", "neutral"),
+    Turn(10, "I press: was Tregaard behind the cleanup?", "recall",
+         targets=("tregaard_target",)),
+    Turn(11, "I thank her, slip her a credit chit, and head back to Ring 3.", "neutral"),
+    Turn(12, "I want to find Mei again. Same stand. Same time slot.", "recall",
+         targets=("mei_fingers",)),
+    Turn(13, "I tell her I want to find someone discreet. I make it clear I'm willing to trade information.", "neutral"),
+    Turn(14, "She mentions a rumor: Helion has a list of station staff who've been flagged 'compromised.' I ask if the junior engineer Rell is on it.", "recall",
+         targets=("rell_jeopardy",)),
+    Turn(15, "If Rell IS on the list, who else is? I push.", "neutral"),
+    Turn(16, "I need to talk to Yulen. Where would they be at this cycle?", "seed", seeds=()),
+    Turn(17, "I find Yulen. What's the first thing about them I notice as they move?", "recall",
+         targets=("yulen_arm",)),
+    Turn(18, "Yulen wants to know why I'm asking about Tregaard. I tell them about the cleanup I think happened — Tregaard should know I have logs.", "recall",
+         targets=("tregaard_target", "tregaard_quiet")),
+    Turn(19, "They name a price. I haggle, expecting their habit.", "neutral"),
+    Turn(20, "Yulen accepts. As they confirm the number, what's the last digit?", "recall",
+         targets=("yulen_seven",)),
+)

--- a/probe/persistence_v2/bibles/nightshift.py
+++ b/probe/persistence_v2/bibles/nightshift.py
@@ -1,0 +1,94 @@
+"""Nightshift — modern-horror bible + 20-turn script.
+
+Late October, 2am, in a rust-belt Ohio town. Player is a crime reporter
+chasing missing-persons leads; recall tests probe whether the model
+carries character voice and consequences in a contemporary idiom.
+"""
+from __future__ import annotations
+
+from .valdremor import Turn, Fact  # reuse dataclasses
+
+
+BIBLE = """## Campaign: Nightshift in Cresford
+
+**Setting:** Cresford, Ohio — a rust-belt town of 14,000 with a downtown that lost its main employer in 2009. Late October, 2am. The 24-hour gas station, the all-night diner, and the river bridge are the only places open. Something has been pulling people out of cars on the river road; the police investigation has gone quiet.
+
+**Player character:** Marin Cole, a 31-year-old crime reporter for the Cresford Sentinel. Her brother went missing in 2018 and she's been chasing missing-persons leads ever since. Sharp, exhausted, mistrustful of cops. Carries a Sony tape recorder she still uses out of habit.
+
+**Recent events:** Last week, Marin interviewed Halloran (a retired detective). He named a place — the old Wilkes farmhouse off County Route 12 — and told her not to go alone. She went anyway. She got out alive but left her phone in the kitchen. She doesn't know yet what found her phone.
+
+**Factions:**
+- **Cresford PD** — the town police force. Sheriff Doyle runs them. Hostile to Marin.
+- **The Riverline group** — informal network of locals who've lost someone. Halloran runs them, quietly.
+
+**Current scene:** Marin is in the booth at Lou's Diner — fluorescent light, coffee cooling in the cup, jukebox not playing, two truckers at the counter not talking to each other.
+"""
+
+NPCS = """### Halloran
+**Role:** Retired detective, runs the informal Riverline group
+**Demeanor:** Sixties, slow, used to be tall and isn't anymore. Hand tremor in his right hand.
+**Speech quirk:** Pauses before saying any name.
+
+### Sheriff Doyle
+**Role:** Cresford PD sheriff, hostile to Marin
+**Demeanor:** Heavyset, cropped grey hair, lab-coat clean department uniform. Smells of cigarettes he claims to have quit.
+**Speech quirk:** Never raises his voice.
+
+### Eli (diner cook)
+**Role:** Lou's Diner night-shift cook, hears everything from the booths
+**Demeanor:** Older Black man, broken nose from a long-ago bar fight, calls every regular by their first name.
+**Speech quirk:** Hums old Motown under his breath while cooking.
+
+### Cathy Wilkes
+**Role:** Daughter of the family who owned the farmhouse on County Route 12
+**Demeanor:** Late forties, gaunt, hasn't slept right in weeks; her left eye twitches when she's lying.
+**Speech quirk:** Says "I don't know" before answering, then answers.
+
+### Garner
+**Role:** Cresford PD deputy, Doyle's enforcer
+**Demeanor:** Heavyset, pale, fingers stained yellow from rolling his own cigarettes.
+**Speech quirk:** Quotes department procedure word-for-word.
+"""
+
+FACTS = (
+    Fact("eli_nose", "Eli the diner cook has a broken nose (old bar fight)"),
+    Fact("eli_motown", "Eli hums old Motown under his breath while cooking"),
+    Fact("cathy_twitch", "Cathy Wilkes's left eye twitches when she's lying"),
+    Fact("doyle_quiet", "Sheriff Doyle never raises his voice; he smells of cigarettes he claims to have quit"),
+    Fact("doyle_hostile", "Sheriff Doyle is hostile to Marin"),
+    Fact("halloran_tremor", "Halloran (the retired detective) has a hand tremor in his right hand"),
+    Fact("halloran_pause", "Halloran pauses before saying any name"),
+    Fact("phone_left", "Marin left her phone in the Wilkes farmhouse kitchen last week (open thread, unresolved)"),
+)
+
+TURNS = (
+    Turn(1,  "I scan the diner. Two truckers. Who's behind the counter tonight.", "neutral"),
+    Turn(2,  "I sit at the counter where the cook works. I order coffee and a slice of pie I don't want.", "seed",
+         seeds=("eli_nose", "eli_motown")),
+    Turn(3,  "I ask the cook if anyone's been talking about County Route 12 this week.", "neutral"),
+    Turn(4,  "I read his answer. If he's hedging, I let it sit. If he's clean, I move on.", "neutral"),
+    Turn(5,  "I pay and head out to my car. The wind off the river smells wet and cold.", "neutral"),
+    Turn(6,  "I drive to Halloran's place. He told me to come if I learned anything new.", "seed",
+         seeds=("phone_left",)),
+    Turn(7,  "I park a block away and walk. I knock at his side door instead of the front.", "neutral"),
+    Turn(8,  "Halloran answers. I tell him I went to the farmhouse and left my phone behind. How does he react?", "recall",
+         targets=("halloran_tremor", "phone_left")),
+    Turn(9,  "I ask him what he thinks happens to people who go to the farmhouse alone. I keep my voice low.", "neutral"),
+    Turn(10, "I ask him about Sheriff Doyle. Is Doyle hiding something?", "recall",
+         targets=("doyle_hostile", "doyle_quiet")),
+    Turn(11, "I leave Halloran. I drive back through downtown toward the diner.", "neutral"),
+    Turn(12, "I want to talk to Eli again. Same diner. Same shift.", "recall",
+         targets=("eli_nose",)),
+    Turn(13, "I tell him I might have something I need help moving. I'm not specific.", "neutral"),
+    Turn(14, "He says there's a list — names the PD has been quietly tracking. I ask if my brother's name is on it.", "recall",
+         targets=("phone_left",)),
+    Turn(15, "If my brother's name IS on it, who else is? I push.", "neutral"),
+    Turn(16, "I need to find Cathy Wilkes. Where would she be at 4am?", "seed", seeds=()),
+    Turn(17, "I find her. She asks if I went to the farmhouse. I tell her I did. What does her face do when she lies?", "recall",
+         targets=("cathy_twitch",)),
+    Turn(18, "Cathy wants to know why I'm asking about Sheriff Doyle. I tell her what Halloran told me — she should know it's not just talk.", "recall",
+         targets=("doyle_hostile",)),
+    Turn(19, "I press her on the farmhouse. I tell her I left my phone in the kitchen. How does she respond?", "neutral"),
+    Turn(20, "I leave with her account. As she walks back into her house, what's the last thing she does — a hesitation, a gesture — that tells me whether she was lying?", "recall",
+         targets=("cathy_twitch",)),
+)

--- a/probe/persistence_v2/bibles/valdremor.py
+++ b/probe/persistence_v2/bibles/valdremor.py
@@ -1,0 +1,113 @@
+"""Valdremor — medieval-fantasy bible + 20-turn script.
+
+A ruined-empire city beneath a still-active volcano. Player is a half-elf
+rogue who let a witness go on her last heist; recall tests probe whether
+the model remembers that choice's consequence across 14+ turns.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+
+TurnKind = Literal["seed", "neutral", "recall"]
+
+
+@dataclass(frozen=True)
+class Turn:
+    idx: int
+    action: str
+    kind: TurnKind
+    seeds: tuple[str, ...] = ()
+    targets: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class Fact:
+    id: str
+    description: str
+
+
+BIBLE = """## Campaign: The Ashen Crown
+
+**Setting:** Valdremor — a city built on the ruins of a destroyed empire. Ash falls from the Cinderpeak volcano to the north. The ruling Merchant Council controls all trade; the Thornwarden thieves' guild controls everything else.
+
+**Player character:** Sable, a half-elf rogue, former Council courier who went rogue after witnessing a Council assassination. Cautious, dry humor, loyal to very few people.
+
+**Recent events:** Three sessions ago, Sable accepted a job from Mira (Thornwarden fixer) to steal a ledger from a Council warehouse. Sable got the ledger but also let a bound warehouse guard go free — a choice that broke the job's clean exit and left a witness.
+
+**Factions:**
+- **Merchant Council** — runs Valdremor. Ruthless, well-funded. Vael's faction.
+- **Thornwarden** — thieves' guild. Mira's faction. In tension with the Council.
+
+**Current scene:** Sable is moving through the Ashmarket — a covered bazaar in Valdremor's lower district, smoky and loud, vendors selling everything from spiced eel to forged travel papers.
+"""
+
+NPCS = """### Mira
+**Role:** Thornwarden fixer
+**Demeanor:** Wiry, 40s, missing the tip of her left index finger. Always negotiating.
+**Speech quirk:** Drops half-finished idioms. Smells of cloves.
+
+### Aldric
+**Role:** Warehouse guard Sable freed
+**Demeanor:** Young, nervous, owes Sable a life debt he doesn't know how to repay.
+**Speech quirk:** Stammers when contradicted.
+
+### Councillor Vael
+**Role:** Merchant Council member who ordered the assassination Sable witnessed
+**Demeanor:** Cold, meticulous, believes the city's survival requires ugly choices.
+**Speech quirk:** Never raises his voice.
+
+### Tessen (spice vendor)
+**Role:** Ashmarket vendor (older woman, broken nose)
+**Demeanor:** Sells clove-bundle wraps from a brass tray. Sharp eyes for trouble.
+**Speech quirk:** Calls everyone "love."
+
+### Brennick
+**Role:** Council guard captain
+**Demeanor:** Heavyset, scarred jaw, hates the Thornwardens.
+**Speech quirk:** Quotes the city charter.
+"""
+
+FACTS = (
+    Fact("mira_clove", "Mira smells of cloves (the bible anchor scent)"),
+    Fact("mira_finger", "Mira is missing the tip of her left index finger"),
+    Fact("aldric_nervous", "Aldric is young and nervous; he owes Sable a life debt"),
+    Fact("vael_quiet", "Vael never raises his voice; he is cold and meticulous"),
+    Fact("vael_assassin", "Vael ordered the assassination Sable witnessed"),
+    Fact("tessen_nose", "Tessen (the spice vendor introduced turn 2) has a broken nose, older, sells clove wraps on a brass tray"),
+    Fact("brennick_charter", "Brennick (Council guard captain) quotes the city charter and has a scarred jaw"),
+    Fact("aldric_freed", "Sable previously freed Aldric during the warehouse job — a choice with consequence"),
+)
+
+TURNS = (
+    Turn(1,  "I move deeper into the Ashmarket, hood up, scanning for tails.", "neutral"),
+    Turn(2,  "I find Tessen's stall and approach casually, keeping my hands visible.", "seed",
+         seeds=("tessen_nose",)),
+    Turn(3,  "I ask her if she knew a ledger came through the warehouse on Eel Street last month.", "neutral"),
+    Turn(4,  "I read her response carefully. If she's hiding something, I lean in and offer coin for the truth.", "neutral"),
+    Turn(5,  "I leave the Ashmarket and head to the Salt Stairs. The fog is thick tonight.", "neutral"),
+    Turn(6,  "Aldric should be on warehouse rotation this week. I find a vantage where I can watch the Council warehouses without being seen.", "seed",
+         seeds=("aldric_freed",)),
+    Turn(7,  "I wait until I see Aldric come off shift. I follow him at a distance.", "neutral"),
+    Turn(8,  "When he's alone in a side alley I step out from behind a stack of crates. 'It's me.' How does he react?", "recall",
+         targets=("aldric_nervous", "aldric_freed")),
+    Turn(9,  "I ask him what the Council is moving through the warehouses now. I tell him I'm not here to hurt him; I just need to know who's directing the operations.", "neutral"),
+    Turn(10, "I press: is Councillor Vael behind it?", "recall",
+         targets=("vael_assassin",)),
+    Turn(11, "I leave Aldric with a small purse and tell him to lay low. I head back to the Ashmarket.", "neutral"),
+    Turn(12, "I look for the spice vendor I spoke to earlier. Same stall. I want to know if she's still there.", "recall",
+         targets=("tessen_nose",)),
+    Turn(13, "I want her name now. I tell her I have something to trade if she helps me.", "neutral"),
+    Turn(14, "She mentions the Thornwarden talk: word is the Council has a ledger of every guard who's been compromised. I tell her about the guard I let go — does that name appear on it?", "recall",
+         targets=("aldric_freed",)),
+    Turn(15, "If Aldric IS on the ledger, who else is? I push for more.", "neutral"),
+    Turn(16, "I need to talk to Mira. Where would she be at this hour?", "seed", seeds=()),
+    Turn(17, "I find her. What does she smell like?", "recall",
+         targets=("mira_clove",)),
+    Turn(18, "Mira wants to know why I'm asking about Vael. I tell her about the assassination I witnessed — she should know that's not just talk.", "recall",
+         targets=("vael_assassin",)),
+    Turn(19, "She names a price. I haggle.", "neutral"),
+    Turn(20, "I leave with her terms. As I'm walking out, what does she do — a gesture, a word — that tells me whether she'll honor the deal?", "recall",
+         targets=("mira_finger",)),
+)

--- a/probe/persistence_v2/calibrate.py
+++ b/probe/persistence_v2/calibrate.py
@@ -1,0 +1,49 @@
+"""Run the 5 hand-crafted calibration cases against the configured judge.
+
+If the judge model has been swapped, run this first to verify the new
+judge agrees with what we expect on each case. Three are PASS cases,
+two are FAIL cases — covers literal/paraphrase/behavioral/silent/
+contradicting forms.
+
+  python -m probe.persistence_v2.calibrate
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+
+import httpx
+
+from .judge import CALIBRATION_CASES, judge_recall
+
+
+async def main() -> int:
+    api_key = os.environ.get("OPENROUTER_API_KEY", "").strip()
+    if not api_key:
+        print("ERROR: set OPENROUTER_API_KEY in env", file=sys.stderr)
+        return 1
+
+    passed = 0
+    failed = 0
+    async with httpx.AsyncClient() as http:
+        for expected, response, fact in CALIBRATION_CASES:
+            r = await judge_recall(
+                response=response, fact_description=fact,
+                http=http, api_key=api_key,
+            )
+            mark = "✓" if r.passed == expected else "✗"
+            print(f"{mark} expected={expected!s:<5} got={r.passed!s:<5} "
+                  f"conf={r.confidence:.2f} :: {r.reason[:100]}")
+            if r.passed == expected:
+                passed += 1
+            else:
+                failed += 1
+
+    total = passed + failed
+    print(f"\n{passed}/{total} calibration cases agree with expected.")
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/probe/persistence_v2/calibrate.py
+++ b/probe/persistence_v2/calibrate.py
@@ -32,10 +32,14 @@ async def main() -> int:
                 response=response, fact_description=fact,
                 http=http, api_key=api_key,
             )
-            mark = "✓" if r.passed == expected else "✗"
-            print(f"{mark} expected={expected!s:<5} got={r.passed!s:<5} "
-                  f"conf={r.confidence:.2f} :: {r.reason[:100]}")
-            if r.passed == expected:
+            mark = "✓" if r.majority_pass == expected else "✗"
+            per_judge = ", ".join(
+                f"{pj.judge.split('/')[-1]}={'P' if pj.passed else 'F'}"
+                for pj in r.per_judge
+            )
+            print(f"{mark} expected={expected!s:<5} ensemble={r.majority_pass!s:<5} "
+                  f"pass_rate={r.pass_rate:.2f} ({per_judge})")
+            if r.majority_pass == expected:
                 passed += 1
             else:
                 failed += 1

--- a/probe/persistence_v2/judge.py
+++ b/probe/persistence_v2/judge.py
@@ -1,0 +1,164 @@
+"""LLM-judge for recall scoring.
+
+For each (response, fact) pair, asks a small judge model whether the
+response demonstrates knowledge of the canon fact. Returns a structured
+JudgeResult so the runner can aggregate over trials.
+
+Default judge: `google/gemini-2.5-flash` via OpenRouter. Cheap, fast,
+semantically sharp. Override with $PROBE_JUDGE_MODEL.
+
+The judge prompt is intentionally biased toward PASS on ambiguous
+cases — we'd rather over-credit subtle behavioral manifestation
+("Mira's hand twitches" implies the missing fingertip canon) than
+penalize correct paraphrasing. Calibration cases in CALIBRATION_CASES
+guard this — run `python -m probe.persistence_v2.calibrate` to verify
+the judge stays honest after a model swap.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+import httpx
+
+
+JUDGE_MODEL = os.environ.get("PROBE_JUDGE_MODEL", "google/gemini-2.5-flash")
+OPENROUTER_BASE = os.environ.get(
+    "PROBE_JUDGE_BASE", "https://openrouter.ai/api/v1",
+)
+
+
+@dataclass(frozen=True)
+class JudgeResult:
+    passed: bool
+    confidence: float          # 0.0..1.0, judge-reported
+    reason: str
+    raw_text: str
+
+
+JUDGE_SYSTEM = (
+    "You judge whether a tabletop-RPG narrator's response demonstrates "
+    "knowledge of a canon fact about the game world.\n\n"
+    "PASS rules (return passed=true):\n"
+    "- The response carries the fact in any form: literal phrasing, "
+    "paraphrase, character voice referring to it, OR visible behavioral "
+    "manifestation (e.g., a 'nervous' NPC trembles or stammers, "
+    "'missing fingertip' NPC's hand is described).\n"
+    "- If the fact has multiple parts (separated by 'and', 'but', "
+    "semicolons), PASS if the response substantively demonstrates AT "
+    "LEAST ONE part. We're measuring memory of the canon, not perfect "
+    "recitation.\n\n"
+    "FAIL rules (return passed=false):\n"
+    "- The response is silent on the fact AND its behavioral signs.\n"
+    "- The response contradicts the fact (e.g., narrator describes a "
+    "trait that is the opposite of canon).\n"
+    "- The response could be written exactly the same way without the "
+    "fact existing in the bible.\n\n"
+    "Default to FAIL only when the response is genuinely silent — when "
+    "in doubt about whether a subtle signal demonstrates the fact, "
+    "lean toward PASS with lower confidence.\n\n"
+    "Output JSON only, no prose around it:\n"
+    "{\n"
+    "  \"passed\": true | false,\n"
+    "  \"confidence\": 0.0..1.0,\n"
+    "  \"reason\": \"one-sentence justification\"\n"
+    "}"
+)
+
+
+async def judge_recall(
+    *,
+    response: str,
+    fact_description: str,
+    http: httpx.AsyncClient,
+    api_key: str,
+    model: Optional[str] = None,
+) -> JudgeResult:
+    """Ask the judge whether `response` demonstrates the `fact`."""
+    used_model = model or JUDGE_MODEL
+    user_text = (
+        f"FACT (the canon you are checking for):\n{fact_description}\n\n"
+        f"NARRATOR RESPONSE (what the model generated):\n{response.strip()}\n\n"
+        "Did the response demonstrate the fact? Output JSON only."
+    )
+    body = {
+        "model": used_model,
+        "messages": [
+            {"role": "system", "content": JUDGE_SYSTEM},
+            {"role": "user", "content": user_text},
+        ],
+        # Generous output cap: Gemini Flash has internal "thinking" tokens
+        # that count against the budget but aren't returned. A 256-cap
+        # routinely got eaten by the thinker, leaving no JSON. 1024 gives
+        # headroom.
+        "max_tokens": 1024,
+        "temperature": 0.0,
+    }
+    try:
+        r = await http.post(
+            f"{OPENROUTER_BASE}/chat/completions",
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+            json=body,
+            timeout=30.0,
+        )
+        r.raise_for_status()
+        data = r.json()
+        choices = data.get("choices", [])
+        raw = choices[0].get("message", {}).get("content", "") if choices else ""
+        raw = (raw or "").strip()
+    except Exception as e:  # noqa: BLE001
+        return JudgeResult(passed=False, confidence=0.0,
+                           reason=f"judge error: {e}", raw_text="")
+
+    cleaned = re.sub(r"^```(?:json)?\s*|\s*```$", "", raw,
+                     flags=re.MULTILINE).strip()
+    try:
+        parsed = json.loads(cleaned)
+    except json.JSONDecodeError:
+        passed_match = re.search(r'"passed"\s*:\s*(true|false)',
+                                 cleaned, re.IGNORECASE)
+        if passed_match:
+            return JudgeResult(
+                passed=passed_match.group(1).lower() == "true",
+                confidence=0.5,
+                reason="parsed lenient (JSON malformed)",
+                raw_text=raw,
+            )
+        return JudgeResult(passed=False, confidence=0.0,
+                           reason="judge produced unparseable output",
+                           raw_text=raw)
+
+    return JudgeResult(
+        passed=bool(parsed.get("passed", False)),
+        confidence=float(parsed.get("confidence", 0.5) or 0.5),
+        reason=str(parsed.get("reason", "")),
+        raw_text=raw,
+    )
+
+
+# Calibration cases. Run via `python -m probe.persistence_v2.calibrate`
+# any time you change the judge model or prompt. All 5 should match
+# expected if the judge is honest.
+CALIBRATION_CASES: list[tuple[bool, str, str]] = [
+    (True,
+     "Aldric jumps when he sees Sable, hand reaching for his sword. Young, nervous.",
+     "Aldric is young and nervous; he owes Sable a life debt"),
+    (True,
+     "The boy yelps. His hand twitches toward his belt knife.",
+     "Aldric is young and nervous; he owes Sable a life debt"),
+    (False,
+     "Aldric whistles a tune and walks off without a word.",
+     "Aldric is young and nervous; he owes Sable a life debt"),
+    (True,
+     "Mira leans in. You smell cloves on her breath.",
+     "Mira smells of cloves (the bible anchor scent)"),
+    (False,
+     "Mira nods. She smells of fresh rain and pine.",
+     "Mira smells of cloves (the bible anchor scent)"),
+]

--- a/probe/persistence_v2/judge.py
+++ b/probe/persistence_v2/judge.py
@@ -1,31 +1,53 @@
-"""LLM-judge for recall scoring.
+"""LLM-judge ensemble for recall scoring.
 
-For each (response, fact) pair, asks a small judge model whether the
-response demonstrates knowledge of the canon fact. Returns a structured
-JudgeResult so the runner can aggregate over trials.
+For each (response, fact) pair, queries N judge models in parallel
+(default 5 from distinct model families) and returns an ensemble
+verdict. Majority PASS = ensemble PASS. Reports per-judge breakdown
+so the runner can compute inter-rater agreement (IRA) for the
+methodology validity check.
 
-Default judge: `google/gemini-2.5-flash` via OpenRouter. Cheap, fast,
-semantically sharp. Override with $PROBE_JUDGE_MODEL.
+Why 5 judges, not 1:
+  Single-judge LLM scoring has two known failure modes — stylistic
+  preferences that don't generalize, and re-run variance. Five judges
+  from distinct training families (OpenAI/Google/Meta/Alibaba/NVIDIA)
+  with each scoring independently is the same principle as peer review
+  or ensemble methods in ML. Inter-rater agreement (Cohen's kappa, mean
+  across all judge pairs) becomes a measurable validity signal: when
+  IRA > 0.5 the judges substantially agreed and the result is more
+  trustworthy; when IRA is low the judges disagreed and the result is
+  in the gray zone.
 
-The judge prompt is intentionally biased toward PASS on ambiguous
-cases — we'd rather over-credit subtle behavioral manifestation
-("Mira's hand twitches" implies the missing fingertip canon) than
-penalize correct paraphrasing. Calibration cases in CALIBRATION_CASES
-guard this — run `python -m probe.persistence_v2.calibrate` to verify
-the judge stays honest after a model swap.
+The default judge ensemble matches the validated list from
+`narrative_probe.py` so contributors switching between probes hit the
+same scoring distribution.
+
+Calibration cases at the bottom of this module — `python -m
+probe.persistence_v2.calibrate` runs them against the full ensemble.
 """
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import re
 from dataclasses import dataclass
+from itertools import combinations
+from statistics import mean
 from typing import Optional
 
 import httpx
 
 
-JUDGE_MODEL = os.environ.get("PROBE_JUDGE_MODEL", "google/gemini-2.5-flash")
+# Five judges from distinct model families. Mirrors the validated
+# ensemble in narrative_probe.py — same set, same rationale.
+DEFAULT_JUDGE_MODELS: list[str] = [
+    "openai/gpt-oss-120b",
+    "google/gemma-3-27b-it",
+    "meta-llama/llama-3.3-70b-instruct",
+    "qwen/qwen3-235b-a22b",
+    "nvidia/nemotron-3-super-120b-a12b",
+]
+
 OPENROUTER_BASE = os.environ.get(
     "PROBE_JUDGE_BASE", "https://openrouter.ai/api/v1",
 )
@@ -33,10 +55,25 @@ OPENROUTER_BASE = os.environ.get(
 
 @dataclass(frozen=True)
 class JudgeResult:
+    """One judge's vote on one (response, fact) pair."""
+    judge: str
     passed: bool
-    confidence: float          # 0.0..1.0, judge-reported
+    confidence: float
     reason: str
     raw_text: str
+
+
+@dataclass(frozen=True)
+class EnsembleResult:
+    """The ensemble's verdict + the underlying per-judge votes."""
+    fact_description: str
+    per_judge: tuple[JudgeResult, ...]
+    # majority_pass = at least ceil(N/2) judges said PASS
+    majority_pass: bool
+    # pass_rate = fraction of judges that said PASS (0.0..1.0)
+    pass_rate: float
+    # agreement = 1.0 if all judges agreed; 0.0 if perfectly split
+    agreement: float
 
 
 JUDGE_SYSTEM = (
@@ -69,31 +106,29 @@ JUDGE_SYSTEM = (
 )
 
 
-async def judge_recall(
+async def _one_judge(
     *,
+    judge_model: str,
     response: str,
     fact_description: str,
     http: httpx.AsyncClient,
     api_key: str,
-    model: Optional[str] = None,
 ) -> JudgeResult:
-    """Ask the judge whether `response` demonstrates the `fact`."""
-    used_model = model or JUDGE_MODEL
+    """One judge's call. Failures degrade to FAIL with confidence 0."""
     user_text = (
         f"FACT (the canon you are checking for):\n{fact_description}\n\n"
         f"NARRATOR RESPONSE (what the model generated):\n{response.strip()}\n\n"
         "Did the response demonstrate the fact? Output JSON only."
     )
     body = {
-        "model": used_model,
+        "model": judge_model,
         "messages": [
             {"role": "system", "content": JUDGE_SYSTEM},
             {"role": "user", "content": user_text},
         ],
-        # Generous output cap: Gemini Flash has internal "thinking" tokens
-        # that count against the budget but aren't returned. A 256-cap
-        # routinely got eaten by the thinker, leaving no JSON. 1024 gives
-        # headroom.
+        # 1024 cap leaves room for reasoning-model thinking tokens.
+        # gpt-oss-120b in particular burns tokens internally; 300 caps
+        # routinely returned empty content.
         "max_tokens": 1024,
         "temperature": 0.0,
     }
@@ -105,7 +140,7 @@ async def judge_recall(
                 "Content-Type": "application/json",
             },
             json=body,
-            timeout=30.0,
+            timeout=45.0,
         )
         r.raise_for_status()
         data = r.json()
@@ -113,38 +148,135 @@ async def judge_recall(
         raw = choices[0].get("message", {}).get("content", "") if choices else ""
         raw = (raw or "").strip()
     except Exception as e:  # noqa: BLE001
-        return JudgeResult(passed=False, confidence=0.0,
-                           reason=f"judge error: {e}", raw_text="")
+        return JudgeResult(
+            judge=judge_model, passed=False, confidence=0.0,
+            reason=f"judge error: {e}", raw_text="",
+        )
 
     cleaned = re.sub(r"^```(?:json)?\s*|\s*```$", "", raw,
                      flags=re.MULTILINE).strip()
     try:
         parsed = json.loads(cleaned)
+        return JudgeResult(
+            judge=judge_model,
+            passed=bool(parsed.get("passed", False)),
+            confidence=float(parsed.get("confidence", 0.5) or 0.5),
+            reason=str(parsed.get("reason", "")),
+            raw_text=raw,
+        )
     except json.JSONDecodeError:
         passed_match = re.search(r'"passed"\s*:\s*(true|false)',
                                  cleaned, re.IGNORECASE)
         if passed_match:
             return JudgeResult(
+                judge=judge_model,
                 passed=passed_match.group(1).lower() == "true",
                 confidence=0.5,
                 reason="parsed lenient (JSON malformed)",
                 raw_text=raw,
             )
-        return JudgeResult(passed=False, confidence=0.0,
-                           reason="judge produced unparseable output",
-                           raw_text=raw)
+        return JudgeResult(
+            judge=judge_model, passed=False, confidence=0.0,
+            reason="judge produced unparseable output", raw_text=raw,
+        )
 
-    return JudgeResult(
-        passed=bool(parsed.get("passed", False)),
-        confidence=float(parsed.get("confidence", 0.5) or 0.5),
-        reason=str(parsed.get("reason", "")),
-        raw_text=raw,
+
+async def judge_recall(
+    *,
+    response: str,
+    fact_description: str,
+    http: httpx.AsyncClient,
+    api_key: str,
+    judge_models: Optional[list[str]] = None,
+) -> EnsembleResult:
+    """Run the full ensemble on one (response, fact) pair. Judges fire
+    in parallel; one slow judge doesn't serialize the others."""
+    models = judge_models or DEFAULT_JUDGE_MODELS
+    results = await asyncio.gather(*[
+        _one_judge(
+            judge_model=m, response=response,
+            fact_description=fact_description, http=http, api_key=api_key,
+        )
+        for m in models
+    ])
+    passes = [j.passed for j in results]
+    pass_rate = sum(passes) / len(passes) if passes else 0.0
+    # Majority threshold: PASS if at least ceil(N/2) judges agree.
+    # For N=5, that's 3.
+    threshold = (len(models) + 1) // 2
+    majority_pass = sum(passes) >= threshold
+    # Agreement: 1.0 if all judges voted the same way, 0.0 if perfectly
+    # split. For N=5 majority case (3-2), agreement = 0.6.
+    agreement = max(sum(passes), len(passes) - sum(passes)) / len(passes)
+    return EnsembleResult(
+        fact_description=fact_description,
+        per_judge=tuple(results),
+        majority_pass=majority_pass,
+        pass_rate=pass_rate,
+        agreement=agreement,
     )
 
 
-# Calibration cases. Run via `python -m probe.persistence_v2.calibrate`
-# any time you change the judge model or prompt. All 5 should match
-# expected if the judge is honest.
+def cohen_kappa_binary(votes_a: list[bool], votes_b: list[bool]) -> float:
+    """Cohen's kappa for two judges' binary votes across N items.
+    kappa = 1.0 → perfect agreement; 0.0 → chance-level; <0 → worse than
+    chance. Returns 0.0 when undefined (e.g., one judge passes everything
+    so chance agreement is 1.0)."""
+    if not votes_a or len(votes_a) != len(votes_b):
+        return 0.0
+    n = len(votes_a)
+    # observed agreement
+    p_o = sum(1 for a, b in zip(votes_a, votes_b) if a == b) / n
+    # expected agreement by chance, given each judge's marginal pass rate
+    p_a_pass = sum(votes_a) / n
+    p_b_pass = sum(votes_b) / n
+    p_e = (p_a_pass * p_b_pass) + ((1 - p_a_pass) * (1 - p_b_pass))
+    if p_e == 1.0:
+        return 1.0 if p_o == 1.0 else 0.0
+    return (p_o - p_e) / (1 - p_e)
+
+
+def compute_ira(
+    ensemble_results: list[EnsembleResult],
+    judge_models: Optional[list[str]] = None,
+) -> dict:
+    """Inter-rater agreement: mean pairwise Cohen's kappa across all
+    items judged by the ensemble. Reports the overall mean + per-pair
+    breakdown so reviewers can see whether one judge is the outlier.
+    """
+    models = judge_models or DEFAULT_JUDGE_MODELS
+    # Collect votes per judge across all items.
+    per_judge_votes: dict[str, list[bool]] = {m: [] for m in models}
+    for er in ensemble_results:
+        for j in er.per_judge:
+            if j.judge in per_judge_votes:
+                per_judge_votes[j.judge].append(j.passed)
+    # Compute pairwise kappa.
+    pair_kappas: dict[str, float] = {}
+    kappas: list[float] = []
+    for a, b in combinations(models, 2):
+        if len(per_judge_votes[a]) != len(per_judge_votes[b]):
+            # shouldn't happen if every ensemble has the same judge set
+            continue
+        k = cohen_kappa_binary(per_judge_votes[a], per_judge_votes[b])
+        key = f"{a.split('/')[-1]} ↔ {b.split('/')[-1]}"
+        pair_kappas[key] = round(k, 3)
+        kappas.append(k)
+    return {
+        "mean_kappa": round(mean(kappas), 3) if kappas else 0.0,
+        "pair_kappas": pair_kappas,
+        "n_items": len(ensemble_results),
+        "per_judge_pass_rate": {
+            j.split('/')[-1]: round(sum(v) / len(v), 3) if v else 0.0
+            for j, v in per_judge_votes.items()
+        },
+    }
+
+
+# ─── Calibration cases (binary expected; the ensemble's majority_pass
+# should match expected on each of these). Run via:
+#   python -m probe.persistence_v2.calibrate
+
 CALIBRATION_CASES: list[tuple[bool, str, str]] = [
     (True,
      "Aldric jumps when he sees Sable, hand reaching for his sword. Young, nervous.",

--- a/probe/persistence_v2/runner.py
+++ b/probe/persistence_v2/runner.py
@@ -1,0 +1,302 @@
+"""Async orchestrator.
+
+Runs (subject × bible × mode × trial) combinations with bounded
+concurrency. Each trial is one full 20-turn conversation against the
+subject + an LLM-judge call per recall fact.
+
+Modes (calibration backbone):
+  naive       — fresh per turn; system prompt + current action only.
+                Floor: 'what can this model do with bible from system
+                prompt alone?'
+  normal      — current production behavior. System + full history.
+  scaffolded  — normal + <reminders> block prepended to each player
+                action. Tests per-turn re-injection of canon.
+  perfect     — normal + full bible re-prepended to each player
+                action. Ceiling: 'if attention to canon is solved,
+                what's the max?'
+
+Without these baselines a persistence number is a floating dimensionless
+quantity. With them, every score becomes a position in a known range.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from statistics import mean, pstdev
+
+import httpx
+
+from .bibles import BIBLES, Bible, fact_by_id, seed_turn_for_fact
+from .judge import JudgeResult, judge_recall
+from .scaffolding import build_recall_reminders
+from .subjects import call_subject
+
+
+Mode = str  # "naive" | "normal" | "scaffolded" | "perfect"
+
+
+@dataclass
+class TurnRecord:
+    idx: int
+    kind: str
+    action: str
+    response: str
+    latency_ms: int
+    judge: dict[str, JudgeResult] = field(default_factory=dict)
+
+
+@dataclass
+class TrialResult:
+    subject: str
+    bible: str
+    mode: Mode
+    trial: int
+    turns: list[TurnRecord]
+    persistence_index: float
+    weighted_persistence_index: float
+    avg_latency_ms: float
+    total_wall_clock_s: float
+
+
+def _action_with_mode(action: str, *, bible: Bible, mode: Mode) -> str:
+    if mode == "naive" or mode == "normal":
+        return action
+    if mode == "scaffolded":
+        reminders = build_recall_reminders(npcs_md=bible.npcs_md)
+        if not reminders:
+            return action
+        return f"{reminders}\n\n{action}"
+    if mode == "perfect":
+        return f"<bible>\n{bible.system_prompt}\n</bible>\n\n{action}"
+    raise ValueError(f"unknown mode {mode}")
+
+
+async def run_trial(
+    *,
+    subject_route: str,
+    bible: Bible,
+    mode: Mode,
+    trial: int,
+    http: httpx.AsyncClient,
+    api_key: str,
+    max_tokens: int = 1024,
+) -> TrialResult:
+    """One full 20-turn conversation for (subject, bible, mode, trial)."""
+    conversation: list[dict] = []
+    turn_records: list[TurnRecord] = []
+    t_start = time.perf_counter()
+
+    for turn in bible.turns:
+        action_text = _action_with_mode(turn.action, bible=bible, mode=mode)
+        if mode == "naive":
+            messages = [{"role": "user", "content": action_text}]
+        else:
+            conversation.append({"role": "user", "content": action_text})
+            messages = conversation
+
+        t0 = time.perf_counter()
+        try:
+            response = await call_subject(
+                route=subject_route,
+                system=bible.system_prompt,
+                messages=messages,
+                api_key=api_key,
+                http=http,
+                max_tokens=max_tokens,
+            )
+        except Exception as e:
+            response = f"[ERROR: {e}]"
+        latency_ms = int((time.perf_counter() - t0) * 1000)
+
+        if mode != "naive":
+            conversation.append({"role": "assistant", "content": response})
+
+        rec = TurnRecord(
+            idx=turn.idx, kind=turn.kind, action=turn.action,
+            response=response, latency_ms=latency_ms,
+        )
+
+        if turn.kind == "recall" and turn.targets:
+            for fact_id in turn.targets:
+                f = fact_by_id(bible, fact_id)
+                if not f:
+                    continue
+                rec.judge[fact_id] = await judge_recall(
+                    response=response,
+                    fact_description=f.description,
+                    http=http,
+                    api_key=api_key,
+                )
+
+        turn_records.append(rec)
+
+    wall = time.perf_counter() - t_start
+
+    pass_vals: list[float] = []
+    weighted_vals: list[tuple[float, float]] = []
+    for r in turn_records:
+        for fid, j in r.judge.items():
+            pass_vals.append(1.0 if j.passed else 0.0)
+            seed_turn = seed_turn_for_fact(bible, fid)
+            if seed_turn is None:
+                distance = float(r.idx)
+            else:
+                distance = max(1, r.idx - seed_turn)
+            weighted_vals.append((1.0 if j.passed else 0.0, distance ** 0.5))
+
+    persistence_index = (mean(pass_vals) * 100) if pass_vals else 0.0
+    if weighted_vals:
+        num = sum(p * w for p, w in weighted_vals)
+        den = sum(w for _, w in weighted_vals)
+        weighted_persistence_index = (num / den * 100) if den > 0 else 0.0
+    else:
+        weighted_persistence_index = 0.0
+
+    avg_latency = mean([r.latency_ms for r in turn_records]) if turn_records else 0.0
+    return TrialResult(
+        subject=subject_route, bible=bible.name, mode=mode, trial=trial,
+        turns=turn_records,
+        persistence_index=round(persistence_index, 1),
+        weighted_persistence_index=round(weighted_persistence_index, 1),
+        avg_latency_ms=round(avg_latency, 0),
+        total_wall_clock_s=round(wall, 1),
+    )
+
+
+async def run_battery(
+    *,
+    subject_routes: list[str],
+    bible_names: list[str],
+    modes: list[Mode],
+    trials: int,
+    api_key: str,
+    concurrency: int = 4,
+    out_dir: Path,
+) -> list[TrialResult]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    results: list[TrialResult] = []
+    sem = asyncio.Semaphore(concurrency)
+
+    async def _bounded(coro):
+        async with sem:
+            return await coro
+
+    async with httpx.AsyncClient() as http:
+        tasks = []
+        for subject_route in subject_routes:
+            for bible_name in bible_names:
+                bible = BIBLES[bible_name]
+                for mode in modes:
+                    for trial in range(trials):
+                        tasks.append(_bounded(run_trial(
+                            subject_route=subject_route, bible=bible,
+                            mode=mode, trial=trial, http=http,
+                            api_key=api_key,
+                        )))
+
+        for done in await asyncio.gather(*tasks, return_exceptions=True):
+            if isinstance(done, BaseException):
+                print(f"  ⚠ trial failed: {done}")
+                continue
+            results.append(done)
+            slug = f"{done.subject.replace('/', '_')}__{done.bible}__{done.mode}__t{done.trial}"
+            (out_dir / f"{slug}.json").write_text(json.dumps(
+                {
+                    "subject": done.subject,
+                    "bible": done.bible,
+                    "mode": done.mode,
+                    "trial": done.trial,
+                    "persistence_index": done.persistence_index,
+                    "weighted_persistence_index": done.weighted_persistence_index,
+                    "avg_latency_ms": done.avg_latency_ms,
+                    "total_wall_clock_s": done.total_wall_clock_s,
+                    "turns": [
+                        {
+                            "idx": r.idx, "kind": r.kind, "action": r.action,
+                            "response": r.response, "latency_ms": r.latency_ms,
+                            "judge": {
+                                fid: {
+                                    "passed": j.passed,
+                                    "confidence": j.confidence,
+                                    "reason": j.reason,
+                                }
+                                for fid, j in r.judge.items()
+                            },
+                        }
+                        for r in done.turns
+                    ],
+                },
+                indent=2,
+            ))
+    return results
+
+
+def aggregate(results: list[TrialResult]) -> dict:
+    cells: dict[tuple[str, str, str], list[TrialResult]] = {}
+    for r in results:
+        cells.setdefault((r.subject, r.bible, r.mode), []).append(r)
+
+    rollup: dict = {"cells": [], "per_subject_mode": {}}
+    for (subject, bible, mode), trials_list in cells.items():
+        ps = [t.persistence_index for t in trials_list]
+        wps = [t.weighted_persistence_index for t in trials_list]
+        lats = [t.avg_latency_ms for t in trials_list]
+        rollup["cells"].append({
+            "subject": subject, "bible": bible, "mode": mode,
+            "trials": len(trials_list),
+            "persistence_mean": round(mean(ps), 1) if ps else 0.0,
+            "persistence_std": round(pstdev(ps), 1) if len(ps) > 1 else 0.0,
+            "weighted_persistence_mean": round(mean(wps), 1) if wps else 0.0,
+            "avg_latency_ms": round(mean(lats), 0) if lats else 0.0,
+        })
+
+    by_sm: dict[str, dict[str, dict]] = {}
+    for cell in rollup["cells"]:
+        by_sm.setdefault(cell["subject"], {})[cell["mode"]] = cell
+    for subject, mode_cells in by_sm.items():
+        agg = {}
+        for mode, _ in mode_cells.items():
+            same = [c for c in rollup["cells"]
+                    if c["subject"] == subject and c["mode"] == mode]
+            if not same:
+                continue
+            agg[mode] = {
+                "persistence_mean": round(mean([c["persistence_mean"] for c in same]), 1),
+                "weighted_persistence_mean": round(mean([c["weighted_persistence_mean"] for c in same]), 1),
+                "avg_latency_ms": round(mean([c["avg_latency_ms"] for c in same]), 0),
+            }
+        rollup["per_subject_mode"][subject] = agg
+
+    return rollup
+
+
+def write_report_md(rollup: dict, out_path: Path, label: str = "") -> None:
+    lines = [f"# persistence_v2 results{f' — {label}' if label else ''}\n"]
+    lines.append("## Per-subject persistence (averaged across all bibles)\n")
+    lines.append("| Subject | Mode | Persistence | Weighted | Latency |")
+    lines.append("|---|---|---|---|---|")
+    subjects = sorted(rollup["per_subject_mode"].keys())
+    for subject in subjects:
+        for mode in ("naive", "normal", "scaffolded", "perfect"):
+            d = rollup["per_subject_mode"][subject].get(mode)
+            if not d:
+                continue
+            lines.append(
+                f"| {subject} | {mode} | {d['persistence_mean']}% | "
+                f"{d['weighted_persistence_mean']}% | {d['avg_latency_ms']}ms |"
+            )
+
+    lines.append("\n## Per-cell detail\n")
+    lines.append("| Subject | Bible | Mode | Trials | Persistence | ±std | Weighted | Latency |")
+    lines.append("|---|---|---|---|---|---|---|---|")
+    cells = sorted(rollup["cells"], key=lambda c: (c["subject"], c["bible"], c["mode"]))
+    for c in cells:
+        lines.append(
+            f"| {c['subject']} | {c['bible']} | {c['mode']} | {c['trials']} | "
+            f"{c['persistence_mean']}% | {c['persistence_std']} | "
+            f"{c['weighted_persistence_mean']}% | {c['avg_latency_ms']}ms |"
+        )
+    out_path.write_text("\n".join(lines) + "\n")

--- a/probe/persistence_v2/runner.py
+++ b/probe/persistence_v2/runner.py
@@ -30,7 +30,12 @@ from statistics import mean, pstdev
 import httpx
 
 from .bibles import BIBLES, Bible, fact_by_id, seed_turn_for_fact
-from .judge import JudgeResult, judge_recall
+from .judge import (
+    DEFAULT_JUDGE_MODELS,
+    EnsembleResult,
+    compute_ira,
+    judge_recall,
+)
 from .scaffolding import build_recall_reminders
 from .subjects import call_subject
 
@@ -45,7 +50,8 @@ class TurnRecord:
     action: str
     response: str
     latency_ms: int
-    judge: dict[str, JudgeResult] = field(default_factory=dict)
+    # fact_id → ensemble verdict (per-judge breakdown lives inside)
+    judge: dict[str, EnsembleResult] = field(default_factory=dict)
 
 
 @dataclass
@@ -55,8 +61,17 @@ class TrialResult:
     mode: Mode
     trial: int
     turns: list[TurnRecord]
+    # Binary headline: fraction of facts the ensemble's majority verdict
+    # said the model demonstrated. Comparable across cells.
     persistence_index: float
+    # Distance-weighted version: each fact weighted by sqrt(turn
+    # distance from seed) so long-range recalls dominate.
     weighted_persistence_index: float
+    # Soft version: mean of per-fact pass_rate (0.0-1.0). Captures
+    # "3/5 judges agreed" partial credit that the binary headline
+    # collapses to 1.0. Lower-resolution than majority_pass but useful
+    # for finer-grained ranking.
+    soft_persistence_index: float
     avg_latency_ms: float
     total_wall_clock_s: float
 
@@ -82,6 +97,7 @@ async def run_trial(
     trial: int,
     http: httpx.AsyncClient,
     api_key: str,
+    judge_models: list[str] | None = None,
     max_tokens: int = 1024,
 ) -> TrialResult:
     """One full 20-turn conversation for (subject, bible, mode, trial)."""
@@ -129,23 +145,31 @@ async def run_trial(
                     fact_description=f.description,
                     http=http,
                     api_key=api_key,
+                    judge_models=judge_models,
                 )
 
         turn_records.append(rec)
 
     wall = time.perf_counter() - t_start
 
+    # Ensemble-aware aggregation: each fact's contribution is the
+    # ensemble majority verdict (binary 1/0 for headline persistence)
+    # AND the underlying pass_rate (continuous 0.0-1.0 for finer-grained
+    # ranking). Headline persistence stays binary so it's directly
+    # comparable across runs + cells.
     pass_vals: list[float] = []
+    soft_pass_vals: list[float] = []
     weighted_vals: list[tuple[float, float]] = []
     for r in turn_records:
         for fid, j in r.judge.items():
-            pass_vals.append(1.0 if j.passed else 0.0)
+            pass_vals.append(1.0 if j.majority_pass else 0.0)
+            soft_pass_vals.append(j.pass_rate)
             seed_turn = seed_turn_for_fact(bible, fid)
             if seed_turn is None:
                 distance = float(r.idx)
             else:
                 distance = max(1, r.idx - seed_turn)
-            weighted_vals.append((1.0 if j.passed else 0.0, distance ** 0.5))
+            weighted_vals.append((1.0 if j.majority_pass else 0.0, distance ** 0.5))
 
     persistence_index = (mean(pass_vals) * 100) if pass_vals else 0.0
     if weighted_vals:
@@ -156,11 +180,13 @@ async def run_trial(
         weighted_persistence_index = 0.0
 
     avg_latency = mean([r.latency_ms for r in turn_records]) if turn_records else 0.0
+    soft_persistence_index = (mean(soft_pass_vals) * 100) if soft_pass_vals else 0.0
     return TrialResult(
         subject=subject_route, bible=bible.name, mode=mode, trial=trial,
         turns=turn_records,
         persistence_index=round(persistence_index, 1),
         weighted_persistence_index=round(weighted_persistence_index, 1),
+        soft_persistence_index=round(soft_persistence_index, 1),
         avg_latency_ms=round(avg_latency, 0),
         total_wall_clock_s=round(wall, 1),
     )
@@ -173,6 +199,7 @@ async def run_battery(
     modes: list[Mode],
     trials: int,
     api_key: str,
+    judge_models: list[str] | None = None,
     concurrency: int = 4,
     out_dir: Path,
 ) -> list[TrialResult]:
@@ -194,7 +221,7 @@ async def run_battery(
                         tasks.append(_bounded(run_trial(
                             subject_route=subject_route, bible=bible,
                             mode=mode, trial=trial, http=http,
-                            api_key=api_key,
+                            api_key=api_key, judge_models=judge_models,
                         )))
 
         for done in await asyncio.gather(*tasks, return_exceptions=True):
@@ -211,6 +238,7 @@ async def run_battery(
                     "trial": done.trial,
                     "persistence_index": done.persistence_index,
                     "weighted_persistence_index": done.weighted_persistence_index,
+                    "soft_persistence_index": done.soft_persistence_index,
                     "avg_latency_ms": done.avg_latency_ms,
                     "total_wall_clock_s": done.total_wall_clock_s,
                     "turns": [
@@ -219,9 +247,18 @@ async def run_battery(
                             "response": r.response, "latency_ms": r.latency_ms,
                             "judge": {
                                 fid: {
-                                    "passed": j.passed,
-                                    "confidence": j.confidence,
-                                    "reason": j.reason,
+                                    "majority_pass": j.majority_pass,
+                                    "pass_rate": j.pass_rate,
+                                    "agreement": j.agreement,
+                                    "per_judge": [
+                                        {
+                                            "judge": pj.judge,
+                                            "passed": pj.passed,
+                                            "confidence": pj.confidence,
+                                            "reason": pj.reason,
+                                        }
+                                        for pj in j.per_judge
+                                    ],
                                 }
                                 for fid, j in r.judge.items()
                             },
@@ -234,15 +271,30 @@ async def run_battery(
     return results
 
 
-def aggregate(results: list[TrialResult]) -> dict:
+def aggregate(
+    results: list[TrialResult],
+    judge_models: list[str] | None = None,
+) -> dict:
+    """Roll trials up into per-cell + per-subject-mode summaries +
+    overall ensemble inter-rater agreement (IRA)."""
     cells: dict[tuple[str, str, str], list[TrialResult]] = {}
     for r in results:
         cells.setdefault((r.subject, r.bible, r.mode), []).append(r)
 
-    rollup: dict = {"cells": [], "per_subject_mode": {}}
+    # Pull every ensemble result across all trials for the global IRA
+    # number.
+    all_ensembles: list[EnsembleResult] = []
+    for r in results:
+        for turn in r.turns:
+            for er in turn.judge.values():
+                all_ensembles.append(er)
+    ira = compute_ira(all_ensembles, judge_models=judge_models)
+
+    rollup: dict = {"cells": [], "per_subject_mode": {}, "ira": ira}
     for (subject, bible, mode), trials_list in cells.items():
         ps = [t.persistence_index for t in trials_list]
         wps = [t.weighted_persistence_index for t in trials_list]
+        sps = [t.soft_persistence_index for t in trials_list]
         lats = [t.avg_latency_ms for t in trials_list]
         rollup["cells"].append({
             "subject": subject, "bible": bible, "mode": mode,
@@ -250,6 +302,7 @@ def aggregate(results: list[TrialResult]) -> dict:
             "persistence_mean": round(mean(ps), 1) if ps else 0.0,
             "persistence_std": round(pstdev(ps), 1) if len(ps) > 1 else 0.0,
             "weighted_persistence_mean": round(mean(wps), 1) if wps else 0.0,
+            "soft_persistence_mean": round(mean(sps), 1) if sps else 0.0,
             "avg_latency_ms": round(mean(lats), 0) if lats else 0.0,
         })
 
@@ -275,9 +328,33 @@ def aggregate(results: list[TrialResult]) -> dict:
 
 def write_report_md(rollup: dict, out_path: Path, label: str = "") -> None:
     lines = [f"# persistence_v2 results{f' — {label}' if label else ''}\n"]
+
+    ira = rollup.get("ira", {})
+    if ira:
+        lines.append("## Inter-rater agreement (judge ensemble)\n")
+        lines.append(
+            f"**Mean pairwise Cohen's kappa: {ira.get('mean_kappa', 0.0)}**  "
+            f"across {ira.get('n_items', 0)} ensemble judgments.\n"
+        )
+        lines.append(
+            "> kappa > 0.6 = substantial agreement (results trustworthy); "
+            "0.4-0.6 = moderate; < 0.4 = limited agreement (treat as "
+            "directional only).\n"
+        )
+        if ira.get("per_judge_pass_rate"):
+            lines.append("**Per-judge pass rate across all items:**\n")
+            for jname, rate in ira["per_judge_pass_rate"].items():
+                lines.append(f"- {jname}: {rate}")
+            lines.append("")
+        if ira.get("pair_kappas"):
+            lines.append("**Pairwise kappa:**\n")
+            for pair, k in sorted(ira["pair_kappas"].items()):
+                lines.append(f"- {pair}: {k}")
+            lines.append("")
+
     lines.append("## Per-subject persistence (averaged across all bibles)\n")
-    lines.append("| Subject | Mode | Persistence | Weighted | Latency |")
-    lines.append("|---|---|---|---|---|")
+    lines.append("| Subject | Mode | Persistence | Soft | Weighted | Latency |")
+    lines.append("|---|---|---|---|---|---|")
     subjects = sorted(rollup["per_subject_mode"].keys())
     for subject in subjects:
         for mode in ("naive", "normal", "scaffolded", "perfect"):
@@ -286,17 +363,19 @@ def write_report_md(rollup: dict, out_path: Path, label: str = "") -> None:
                 continue
             lines.append(
                 f"| {subject} | {mode} | {d['persistence_mean']}% | "
+                f"{d.get('soft_persistence_mean', '—')}% | "
                 f"{d['weighted_persistence_mean']}% | {d['avg_latency_ms']}ms |"
             )
 
     lines.append("\n## Per-cell detail\n")
-    lines.append("| Subject | Bible | Mode | Trials | Persistence | ±std | Weighted | Latency |")
-    lines.append("|---|---|---|---|---|---|---|---|")
+    lines.append("| Subject | Bible | Mode | Trials | Persistence | ±std | Soft | Weighted | Latency |")
+    lines.append("|---|---|---|---|---|---|---|---|---|")
     cells = sorted(rollup["cells"], key=lambda c: (c["subject"], c["bible"], c["mode"]))
     for c in cells:
         lines.append(
             f"| {c['subject']} | {c['bible']} | {c['mode']} | {c['trials']} | "
             f"{c['persistence_mean']}% | {c['persistence_std']} | "
+            f"{c.get('soft_persistence_mean', '—')}% | "
             f"{c['weighted_persistence_mean']}% | {c['avg_latency_ms']}ms |"
         )
     out_path.write_text("\n".join(lines) + "\n")

--- a/probe/persistence_v2/runner.py
+++ b/probe/persistence_v2/runner.py
@@ -318,6 +318,7 @@ def aggregate(
                 continue
             agg[mode] = {
                 "persistence_mean": round(mean([c["persistence_mean"] for c in same]), 1),
+                "soft_persistence_mean": round(mean([c.get("soft_persistence_mean", 0.0) for c in same]), 1),
                 "weighted_persistence_mean": round(mean([c["weighted_persistence_mean"] for c in same]), 1),
                 "avg_latency_ms": round(mean([c["avg_latency_ms"] for c in same]), 0),
             }

--- a/probe/persistence_v2/scaffolding.py
+++ b/probe/persistence_v2/scaffolding.py
@@ -1,0 +1,89 @@
+"""Recall scaffolding parser — builds <reminders> block from a bible.
+
+Parses the bible's `### NPC Name` markdown sections and extracts the
+most sensory-anchored 1-2 trait lines per NPC. The resulting block
+gets prepended to a player's action message when the runner is in
+scaffolded mode.
+
+Pure regex, no external deps. The tabletop-RPG bible format here is
+the same one [claude-dnd-skill](https://github.com/Bobby-Gray/claude-dnd-skill)
+ships in `templates/npcs.md`.
+"""
+from __future__ import annotations
+
+import re
+
+MAX_REMINDED_NPCS = 6
+
+_NPC_HEADER_RE = re.compile(r"^###\s+(?P<name>[^\n]+?)\s*$", re.MULTILINE)
+_LABELED_TRAIT_RE = re.compile(
+    # Accept both `**Label:**` (label+colon inside bold) and `**Label**:`
+    # (colon outside bold). Bible authors waver between the two; the
+    # probe shouldn't care.
+    r"^\*\*(Role|Demeanor|Speech quirk|Motivation|Secret):?\*\*:?\s*(?P<value>[^\n]+)",
+    re.MULTILINE | re.IGNORECASE,
+)
+
+
+def _condense(text: str, *, max_chars: int = 110) -> str:
+    """Keep first sentence + char cap so reminder blocks stay lean."""
+    text = text.strip()
+    cut = re.split(r"(?<=[.!?])\s+", text, maxsplit=1)[0]
+    if len(cut) > max_chars:
+        return cut[: max_chars - 1].rstrip() + "…"
+    return cut
+
+
+def _extract_npcs(npcs_md: str) -> list[tuple[str, str]]:
+    if not npcs_md:
+        return []
+    headers = list(_NPC_HEADER_RE.finditer(npcs_md))
+    out: list[tuple[str, str]] = []
+    for i, m in enumerate(headers):
+        name = m.group("name").strip()
+        start = m.end()
+        end = headers[i + 1].start() if i + 1 < len(headers) else len(npcs_md)
+        section = npcs_md[start:end]
+        traits: list[str] = []
+        for tm in _LABELED_TRAIT_RE.finditer(section):
+            label = tm.group(1).lower()
+            value = _condense(tm.group("value"))
+            if not value:
+                continue
+            # Prefer Demeanor + Speech quirk (sensory anchors); fall back
+            # to Role + Motivation only if those didn't land.
+            if label in ("demeanor", "speech quirk"):
+                traits.append(value)
+            elif label in ("role", "motivation") and len(traits) < 2:
+                traits.append(value)
+            if len(traits) >= 2:
+                break
+        condensed = "; ".join(traits) if traits else ""
+        out.append((name, condensed))
+        if len(out) >= MAX_REMINDED_NPCS:
+            break
+    return out
+
+
+def build_recall_reminders(*, npcs_md: str | None) -> str:
+    """Return the reminder block; empty string when the bible yields
+    no usable NPC data."""
+    if not npcs_md:
+        return ""
+    npcs = _extract_npcs(npcs_md)
+    if not npcs:
+        return ""
+    lines = ["<reminders>", "Active NPCs:"]
+    for name, traits in npcs:
+        if traits:
+            lines.append(f"- {name}: {traits}")
+        else:
+            lines.append(f"- {name}")
+    lines.append("</reminders>")
+    return "\n".join(lines)
+
+
+def append_reminders_to_action(action: str, reminders: str) -> str:
+    if not reminders:
+        return action
+    return f"{reminders}\n\n{action}"

--- a/probe/persistence_v2/subjects.py
+++ b/probe/persistence_v2/subjects.py
@@ -1,0 +1,43 @@
+"""Subject-model API client (OpenRouter only).
+
+Distinct from `judge.py` so contributors can swap judges/subjects
+independently. Both go through OpenRouter; both take the same API
+key from $OPENROUTER_API_KEY.
+"""
+from __future__ import annotations
+
+import httpx
+
+
+OPENROUTER_BASE = "https://openrouter.ai/api/v1"
+
+
+async def call_subject(
+    *,
+    route: str,
+    system: str,
+    messages: list[dict],
+    api_key: str,
+    http: httpx.AsyncClient,
+    max_tokens: int = 1024,
+    temperature: float = 0.85,
+) -> str:
+    """Run the subject model on (system, messages). Returns plain text."""
+    msgs = [{"role": "system", "content": system}, *messages]
+    r = await http.post(
+        f"{OPENROUTER_BASE}/chat/completions",
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+        json={
+            "model": route,
+            "messages": msgs,
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+        },
+        timeout=180.0,
+    )
+    r.raise_for_status()
+    data = r.json()
+    return data["choices"][0]["message"]["content"]


### PR DESCRIPTION
## Summary

A methodologically rigorous, multi-turn story-persistence probe to complement `narrative_probe.py`. Holds state across 20 scripted turns the way a real session does, then scores recall semantically via a **5-judge ensemble** with **Cohen's kappa inter-rater agreement** so the scoring side is defensible — same methodology shape `narrative_probe.py` already uses.

The two probes measure different things — `narrative_probe.py` covers atmosphere / npc_craft / gm_craft on single turns; this one covers **whether the model remembers what the bible established 6-15 turns later**. Run both for a complete model evaluation.

## What lands

1. **Judge ensemble (5 models, distinct families)** with Cohen's kappa IRA — kills single-judge stylistic bias and gives a measurable validity signal. Same default judges as `narrative_probe.py`. Calibration cases pass 5/5 unanimous.
2. **Three distinct bibles** (medieval fantasy / sci-fi / modern horror), sized identically (5 NPCs, 2 factions, 20 turns, ~7 recall tests) so the persistence index is comparable across them. Detects when a model's recall is only good inside its training-distribution sweet spot.
3. **N-trial per cell** (default 2); persistence_mean ± pstdev reported. Single-shot variance no longer invisible.
4. **Four calibration modes** — naive (no history) / normal (production) / scaffolded (per-turn reminder block from bible) / perfect (full bible re-issued every turn). Without these, persistence numbers float; with them every score sits in a known measurement range.
5. **Three persistence metrics** per cell:
   - **persistence_index** (binary majority verdict — headline)
   - **soft_persistence_index** (mean per-fact pass_rate — catches 3/5 partial credit the binary collapses to 1.0)
   - **weighted_persistence_index** (distance-from-seed weighted — long-range recall dominates)

## Smoke + calibration

- [x] \`python -m probe.persistence_v2.calibrate\` → 5/5 unanimous on the ensemble
- [x] Smoke 1 trial (Sonnet × Valdremor × normal) → IRA 0.8 (substantial agreement) across 8 judgments

## Cost

Full battery — 4 subjects × 3 bibles × 4 modes × 2 trials × ~7 recall tests × 5 judges ≈ 1.7k subject calls + 3.3k judge calls. Around \$3-5 of OpenRouter usage at typical rates. Most of the spend is the subject calls; the judge ensemble adds ~\$0.50.

## Known limitations (called out in README + commit messages)

- **Single-shot generation per cell** — judges are 5-fold but each model still generates once per (bible, mode, trial). IRA tells you how much the judges agreed; it doesn't tell you whether a different generation seed would have moved the score. Treat as directional rankings.
- **Scripted player path** — actions are pre-written. Real chat usage is reactive; a future v3 would have actions react to the model's output.
- **Measures memory, not prose quality** — pair with `narrative_probe.py` for the qualitative dimension.