### PR TITLE
fix(display): PARTY INPUT covers text + honest send-failure (sync from claude-dnd-skill v2.2.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ This project is the LLM-agnostic, system-flexible fork of [claude-dnd-skill](htt
 
 ## [Unreleased]
 
+### Display input fixes (synced from claude-dnd-skill)
+
+- **The PARTY INPUT box no longer covers the bottom of the narration.** The fixed input panel grows when it expands (or the editorial drawer opens, or the mobile keyboard raises the viewport); a `ResizeObserver` now keeps `#text-scroll`'s bottom padding synced to the panel's live on-screen footprint so the last lines of narration always clear it. No-op in phone input-only mode.
+- **A failed player-input submit now says so.** If the browser→server POST fails after retries, the Stage button shows "Send failed — tap to retry" (the typed text and its `localStorage` cache are preserved, so a tap re-sends) instead of silently resetting to "Stage" — which previously read as "submitted but not acknowledged."
+
 ### Sync from claude-dnd-skill v2.1.x — backend + GM-side discipline
 
 Ports the system-agnostic portions of the v2.1.0–v2.1.4 upstream lineup. Backend infrastructure and GM-side docs land here; the deeper phone UX bits (on-screen dice drawer for no-phones games, per-PC Rolls toggle in phone Settings, status-strip rewrite for one-tap send) are deferred to a follow-up PR to be adapted properly against OTGM's tab-based phone UX.

--- a/display/templates/index.html
+++ b/display/templates/index.html
@@ -6051,6 +6051,8 @@ async function _stageAction() {
   localStorage.setItem('dnd_staged_input', JSON.stringify({ char: _selectedChar, text, ts: Date.now() }));
 
   let attempts = 0;
+  let _sent = false;
+  let _lastStatus = 0;
   while (attempts < 3) {
     attempts++;
     try {
@@ -6059,6 +6061,7 @@ async function _stageAction() {
         headers: _authHeaders(),
         body: JSON.stringify({ character: _selectedChar, text }),
       });
+      _lastStatus = res.status;
       if (res.status === 202) {
         // Device pending approval — persist state so it survives page reload
         localStorage.setItem('dnd_awaiting_approval', _deviceId);
@@ -6070,6 +6073,7 @@ async function _stageAction() {
         localStorage.removeItem('dnd_staged_input');
         localStorage.removeItem('dnd_awaiting_approval');
         _inputText.value = '';
+        _sent = true;
         break;
       }
       // Non-retriable error (403, 400, etc.)
@@ -6082,7 +6086,16 @@ async function _stageAction() {
     }
   }
   _stageBtn.disabled = false;
-  _stageBtn.textContent = 'Stage';
+  if (_sent) {
+    _stageBtn.textContent = 'Stage';
+  } else {
+    // Honest failure: the text + the dnd_staged_input cache are preserved, so a
+    // tap re-sends without retyping. Never silently reset to 'Stage' on failure —
+    // that's what read as "submitted but not acknowledged, gone forever".
+    _stageBtn.textContent = _lastStatus
+      ? `Send failed (${_lastStatus}) — tap to retry`
+      : 'Send failed — tap to retry';
+  }
 }
 
 // ── Toggle ready for a staged char ───────────────────────────────
@@ -6128,6 +6141,34 @@ _inputText.addEventListener('keydown', e => {
     _stageAction();
   }
 });
+
+// ── Keep the reading column clear of the fixed PARTY INPUT panel ──────
+// #input-panel is position:fixed at the bottom; when it expands (or the
+// editorial drawer slides open, or the mobile keyboard raises the viewport)
+// it overlaps the last lines of narration. Reserve #text-scroll bottom padding
+// equal to the panel's live on-screen footprint so the text always clears it.
+function _reserveInputSpace() {
+  const panel  = document.getElementById('input-panel');
+  const scroll = document.getElementById('text-scroll');
+  if (!panel || !scroll) return;
+  // Phone input-only mode: #text-scroll isn't the reading surface there.
+  if (document.body.classList.contains('input-only')) { scroll.style.paddingBottom = ''; return; }
+  // Panel hidden (display:none → 0 rect) or fully below the fold (closed drawer) → CSS baseline stands.
+  // NB: don't use offsetParent for visibility here — it is always null for position:fixed elements.
+  const rect = panel.getBoundingClientRect();
+  if (rect.height === 0 || rect.top >= window.innerHeight) { scroll.style.paddingBottom = ''; return; }
+  const reserve = Math.round(window.innerHeight - rect.top) + 16;
+  scroll.style.paddingBottom = Math.max(40, reserve) + 'px';
+}
+
+(function _initReserveInputSpace() {
+  const panel = document.getElementById('input-panel');
+  if (window.ResizeObserver && panel) new ResizeObserver(_reserveInputSpace).observe(panel);
+  if (panel) panel.addEventListener('transitionend', _reserveInputSpace); // drawer slide / collapse
+  window.addEventListener('resize', _reserveInputSpace);
+  if (window.visualViewport) window.visualViewport.addEventListener('resize', _reserveInputSpace);
+  _reserveInputSpace();
+})();
 
 // Initialise with no extra chars (populated when stats arrive)
 _buildCharTabs([]);


### PR DESCRIPTION
Ports the two claude-dnd-skill v2.2.2 display-companion fixes to OTGM's identical `#input-panel` flow, verified live with Playwright on the OTGM display.

1. **PARTY INPUT box covered the narration** → `ResizeObserver` reserves `#text-scroll` bottom padding to the panel's live footprint (no-op in phone input-only mode).
2. **Silent send-failure** → 'Send failed — tap to retry' instead of resetting to 'Stage'; text + `localStorage` cache already preserved.

Verified: no JS errors; padding reserves footprint collapsed (73≥57) and expanded (211≥195); failure path shows retry affordance.

Lands in **[Unreleased]** with no VERSION bump — the existing v2.1.x sync is also pending there, so the next OTGM release (and whether it's a patch or minor) is a separate maintainer decision.