### PR TITLE
fix(display): make the GM hint model-agnostic, not Claude-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ This project is the LLM-agnostic, system-flexible fork of [claude-dnd-skill](htt
 
 ## [Unreleased]
 
+### Model-agnostic GM hint (thanks @eviloverclaude)
+
+- **The ◈ GM Help hint no longer depends on Claude.** `dm_help.py` previously shelled out to a hardcoded `claude -p --model claude-sonnet-4-6`, so the feature silently produced nothing for anyone running OTGM through opencode, gemini, mistral, or any non-Claude tooling. It now resolves a backend portably: set `OTGM_HINT_CMD` to your own model command (prompt on stdin, hint on stdout), or let OTGM auto-detect a known CLI on `PATH` (`claude`, `opencode`, `gemini`, `llm`). `OTGM_HINT_MODEL` pins a model for the auto-detected backend; `OTGM_HINT_TIMEOUT` bounds the call. Claude still works out of the box but is no longer a dependency, and with no backend available the feature no-ops instead of breaking play.
+- **Fixed `push_stats.py` reading the display token from a hardcoded `~/.claude/skills/dnd/display/.token`** instead of its own display directory like every sibling script. This broke stat pushes for any install outside the Claude skill path.
+
 ### Display input fixes (synced from claude-dnd-skill)
 
 - **The PARTY INPUT box no longer covers the bottom of the narration.** The fixed input panel grows when it expands (or the editorial drawer opens, or the mobile keyboard raises the viewport); a `ResizeObserver` now keeps `#text-scroll`'s bottom padding synced to the panel's live on-screen footprint so the last lines of narration always clear it. No-op in phone input-only mode.

--- a/display/README.md
+++ b/display/README.md
@@ -198,6 +198,15 @@ Enable autorun:
 
 The ◈ button in the top-right corner fires a one-shot hint from `dm_help.py` — a single `--tutor` block appears in the feed with a tactical suggestion for the current situation. This is separate from tutor mode (`/gm tutor on`) which appends hints to every response.
 
+**Which model generates the hint** is model-agnostic — OTGM shells out to whatever code-driven LLM you already run, with no hard dependency on any vendor:
+
+- `OTGM_HINT_CMD` — set this to your model command and OTGM uses it verbatim. The command receives the full prompt on **stdin** and must print the hint to **stdout**. Examples: `export OTGM_HINT_CMD='llm -m mistral-large-latest'`, `export OTGM_HINT_CMD='gemini -p'`, `export OTGM_HINT_CMD='claude -p'`.
+- If unset, OTGM auto-detects a known CLI on `PATH` (`claude`, `opencode`, `gemini`, `llm`) and uses its non-interactive mode. Claude is supported but never required.
+- `OTGM_HINT_MODEL` — optionally pin a model for the auto-detected backend.
+- `OTGM_HINT_TIMEOUT` — seconds before the hint call is abandoned (default 60).
+
+If no backend is found, the hint feature simply no-ops — a missing or misconfigured model degrades to "no hint," it never interrupts play.
+
 ### Sound effects
 
 `audio.py` scans narration text server-side via compiled regex patterns. On a match it broadcasts `{"sfx": name}` to all connected browsers via SSE. The browser fetches the WAV file from `/audio/sfx/<name>` (synthesized on demand, cached after first request) and plays it via Web Audio API.

--- a/display/dm_help.py
+++ b/display/dm_help.py
@@ -20,8 +20,11 @@ Lock lifecycle:
 
 import argparse
 import json
+import os
 import pathlib
 import re
+import shlex
+import shutil
 import subprocess
 import sys
 
@@ -210,8 +213,58 @@ def get_session_context(campaign: str) -> str:
     return "\n".join(lines)
 
 
-def call_claude(display: str, state: str, session: str, arc: str) -> str:
-    """Call claude -p (non-interactive print mode) — uses Claude Code's own auth."""
+HINT_TIMEOUT = int(os.environ.get("OTGM_HINT_TIMEOUT", "60"))
+
+
+def _resolve_hint_backend(system: str, prompt: str):
+    """
+    Resolve which code-driven LLM generates the hint, and the text to feed it.
+
+    Returns (argv, stdin_text), or (None, None) when no backend is available.
+
+    Portability contract — OTGM depends on no single model or vendor:
+      * OTGM_HINT_CMD names the command explicitly. It receives the full prompt on
+        stdin and must print the hint to stdout. Works with any model/CLI, e.g.:
+            export OTGM_HINT_CMD='llm -m mistral-large-latest'
+            export OTGM_HINT_CMD='gemini -p'
+            export OTGM_HINT_CMD='claude -p'
+        This is the authoritative escape hatch — set it and OTGM uses it verbatim.
+      * If unset, auto-detect a known CLI on PATH (claude, opencode, gemini, llm)
+        and use its non-interactive mode. Claude is supported, never required.
+      * OTGM_HINT_MODEL optionally pins a model for the auto-detected backend.
+      * If nothing is found the hint feature no-ops; play is never interrupted.
+    """
+    folded = f"{system}\n\n---\n\n{prompt}"
+
+    override = os.environ.get("OTGM_HINT_CMD", "").strip()
+    if override:
+        return shlex.split(override), folded
+
+    model = os.environ.get("OTGM_HINT_MODEL", "").strip()
+
+    # Every backend reads the prompt on stdin and prints the hint to stdout.
+    if shutil.which("claude"):
+        argv = ["claude", "-p", "--system-prompt", system]
+        if model:
+            argv += ["--model", model]
+        return argv, prompt  # claude accepts the system prompt natively
+    if shutil.which("opencode"):
+        return ["opencode", "run"] + (["--model", model] if model else []), folded
+    if shutil.which("gemini"):
+        return ["gemini"] + (["-m", model] if model else []), folded
+    if shutil.which("llm"):
+        return ["llm"] + (["-m", model] if model else []), folded
+
+    return None, None
+
+
+def call_model(display: str, state: str, session: str, arc: str) -> str:
+    """
+    Generate a GM hint via whatever code-driven LLM the operator runs.
+    Model-agnostic by design (see _resolve_hint_backend for the contract).
+    Returns "SKIP" when no backend is available or the call fails, so a missing
+    or misconfigured model degrades to "no hint" rather than breaking play.
+    """
     system = (
         "You are a tabletop RPG Game Master generating a brief in-character GM hint. "
         "You are given three sources of context in decreasing order of freshness: "
@@ -252,17 +305,20 @@ def call_claude(display: str, state: str, session: str, arc: str) -> str:
 
     prompt = "\n\n".join(prompt_parts)
 
-    result = subprocess.run(
-        [
-            "claude", "-p",
-            "--model", "claude-sonnet-4-6",
-            "--system-prompt", system,
-            prompt,
-        ],
-        capture_output=True,
-        text=True,
-        timeout=60,
-    )
+    argv, stdin_text = _resolve_hint_backend(system, prompt)
+    if argv is None:
+        return "SKIP"
+
+    try:
+        result = subprocess.run(
+            argv,
+            input=stdin_text,
+            capture_output=True,
+            text=True,
+            timeout=HINT_TIMEOUT,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return "SKIP"
 
     if result.returncode != 0:
         return "SKIP"
@@ -293,7 +349,7 @@ def main() -> None:
         if not display and not state and not session:
             return
 
-        hint = call_claude(display, state, session, arc)
+        hint = call_model(display, state, session, arc)
         if hint.strip().upper() == "SKIP":
             return
 

--- a/display/push_stats.py
+++ b/display/push_stats.py
@@ -80,7 +80,7 @@ _DISPLAY_DIR = os.path.dirname(os.path.abspath(__file__))
 _SCHEME_FILE = os.path.join(_DISPLAY_DIR, ".scheme")
 _SCHEME = open(_SCHEME_FILE).read().strip() if os.path.exists(_SCHEME_FILE) else "http"
 FLASK_URL  = f"{_SCHEME}://localhost:5001/stats"
-TOKEN_FILE = os.path.expanduser("~/.claude/skills/dnd/display/.token")
+TOKEN_FILE = os.path.join(_DISPLAY_DIR, ".token")
 TIMEOUT    = 2.0
 
 # SSL context — only used when running HTTPS (self-signed cert)


### PR DESCRIPTION
Closes the Claude coupling @eviloverclaude flagged in #25.

`dm_help.py` hardcoded `claude -p --model claude-sonnet-4-6`, so the ◈ GM Help hint silently did nothing for anyone running OTGM through opencode / gemini / mistral / non-Claude tooling. The model call is now portable:

- `OTGM_HINT_CMD` — your command, prompt on stdin, hint on stdout (authoritative escape hatch; works with any model)
- else auto-detect a CLI on PATH (`claude`, `opencode`, `gemini`, `llm`)
- `OTGM_HINT_MODEL` pins a model; `OTGM_HINT_TIMEOUT` bounds the call
- no backend found → no-op, play continues

Claude still works out of the box, just no longer required.

Also fixes `push_stats.py` reading the display token from a hardcoded `~/.claude/skills/dnd/display/.token` instead of its own display dir (broke stat pushes outside the Claude skill path).

Documented in `display/README.md` + CHANGELOG.