### PR TITLE
feat(display): system-agnostic character UI — manifest-driven sidebar + sheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ This project is the LLM-agnostic, system-flexible fork of [claude-dnd-skill](htt
 
 ## [Unreleased]
 
+### System-agnostic character UI (systems can define their own sidebar + sheet)
+
+- **The character sidebar and sheet are now driven by a per-system UI manifest** instead of a hardcoded D&D layout. A system ships `systems/<name>/ui.json` describing its sidebar widgets, sheet combat strip, and attribute grid; the display renders from it. A new system becomes a ~40-line JSON file rather than new front-end code. See `systems/UI-MANIFEST.md` for the widget catalog and a Shadowrun 5e example, and `systems/dnd5e/ui.json` for the reference manifest.
+- **Backward compatible.** The renderer carries a built-in default manifest that reproduces the original D&D 5e display exactly, so campaigns with no `ui.json` (or no system declared) look identical to before. The attribute grid now also supports raw ratings (`show_modifier: false`) for dice-pool systems, not just D&D's score+modifier.
+- A campaign selects its system module with a `**System Module:** <name>` line in `state.md` (distinct from the human-readable `**System:**` label); absent ⇒ `dnd5e`. New `paths.campaign_system()` resolves it. Switching systems takes effect on the next display load.
+
 ### Model-agnostic GM hint (thanks @eviloverclaude)
 
 - **The ◈ GM Help hint no longer depends on Claude.** `dm_help.py` previously shelled out to a hardcoded `claude -p --model claude-sonnet-4-6`, so the feature silently produced nothing for anyone running OTGM through opencode, gemini, mistral, or any non-Claude tooling. It now resolves a backend portably: set `OTGM_HINT_CMD` to your own model command (prompt on stdin, hint on stdout), or let OTGM auto-detect a known CLI on `PATH` (`claude`, `opencode`, `gemini`, `llm`). `OTGM_HINT_MODEL` pins a model for the auto-detected backend; `OTGM_HINT_TIMEOUT` bounds the call. Claude still works out of the box but is no longer a dependency, and with no backend available the feature no-ops instead of breaking play.

--- a/display/gm-display-app.py
+++ b/display/gm-display-app.py
@@ -22,6 +22,7 @@ Endpoints:
 
 import hmac
 import json
+import pathlib
 import os
 import queue
 import re
@@ -50,7 +51,11 @@ except Exception:
     _lookup = None          # type: ignore
     _SRD_AVAILABLE = False
 
-from paths import campaign_dir as _campaign_dir, find_campaign as _find_campaign
+from paths import (
+    campaign_dir as _campaign_dir,
+    find_campaign as _find_campaign,
+    campaign_system as _campaign_system,
+)
 
 # Audio module — degrades silently if numpy not installed
 import sys as _sys
@@ -1101,6 +1106,36 @@ def _broadcast(payload: dict) -> None:
 
 # ─── Routes ──────────────────────────────────────────────────────────────────
 
+_SYSTEMS_DIR = pathlib.Path(__file__).resolve().parent.parent / "systems"
+
+
+def _load_ui_manifest() -> str:
+    """Return the active campaign's system UI manifest as a JSON string for the template.
+
+    Resolves active campaign → system name → systems/<system>/ui.json. Returns
+    "null" when there is no campaign, no ui.json, or the file is unreadable/invalid;
+    the browser then falls back to its built-in default manifest (the D&D layout),
+    so the display renders identically with or without a manifest file.
+
+    Resolved at page render. Switching systems takes effect on the next display
+    load — and the display is force-restarted each session, so this is a non-issue
+    in normal use.
+    """
+    name = _active_campaign_name()
+    if not name:
+        return "null"
+    try:
+        system = _campaign_system(name)
+        path = _SYSTEMS_DIR / system / "ui.json"
+        if not path.exists():
+            return "null"
+        manifest = json.loads(path.read_text(errors="replace"))
+    except (OSError, ValueError):
+        return "null"
+    # Compact, and neutralize any "</script>" that could break the inline tag.
+    return json.dumps(manifest, separators=(",", ":")).replace("<", "\\u003c")
+
+
 @app.route("/")
 def index():
     # Pass LAN token to template so the browser can authenticate /help-request
@@ -1109,6 +1144,7 @@ def index():
         lan_token=_lan_token or "",
         narrator_voice=_read_narrator_voice(),
         tts_available=(_tts is not None),
+        ui_manifest=_load_ui_manifest(),
     )
 
 

--- a/display/templates/index.html
+++ b/display/templates/index.html
@@ -9,6 +9,12 @@
 <meta name="narrator-voice" content="{{ narrator_voice }}">
 <meta name="tts-available" content="{{ '1' if tts_available else '0' }}">
 
+<!-- Active system's UI manifest (systems/<system>/ui.json), injected by Flask.
+     Drives the per-system character sidebar + sheet. `null` ⇒ the JS falls back
+     to its built-in D&D 5e default, so the display renders identically with or
+     without a manifest. See systems/UI-MANIFEST.md. -->
+<script>window.GM_UI_MANIFEST = {{ ui_manifest|safe }};</script>
+
 <!-- Theme anti-FOUC. Runs synchronously before the stylesheet parses so the
      correct data-theme attribute is on <html> before any rule resolves —
      prevents a dark→light or light→dark flash on every load. Three states:
@@ -4491,6 +4497,238 @@ function _hpColor(pct) {
   return '#a03030';
 }
 
+// ══════════════════════════════════════════════════════════════════════
+// SYSTEM UI MANIFEST — per-system character sidebar + sheet rendering.
+//
+// The server injects the active system's systems/<system>/ui.json as
+// window.GM_UI_MANIFEST. When it's null/invalid we fall back to
+// DEFAULT_UI_MANIFEST below, which reproduces the original hardcoded D&D 5e
+// layout exactly — so the display renders identically with or without a
+// manifest file. A new game system ships its own ui.json to define its
+// sidebar widgets, combat strip, and attribute grid. See systems/UI-MANIFEST.md.
+//
+// Widgets are self-hiding: each renders nothing when its bound field is absent,
+// so a manifest declares the superset of what *can* show and the pushed stats
+// decide what actually renders.
+// ══════════════════════════════════════════════════════════════════════
+
+const _DEFAULT_CONDITION_CLASS = {
+  unconscious: 'danger', paralyzed: 'danger', petrified: 'danger', stunned: 'danger',
+  incapacitated: 'warn', frightened: 'warn', poisoned: 'warn', charmed: 'warn', exhausted: 'warn',
+  grappled: 'info', restrained: 'info', prone: 'info', blinded: 'info', deafened: 'info',
+  invisible: 'buff',
+};
+
+const DEFAULT_UI_MANIFEST = {
+  manifest_version: 1, system: 'dnd5e', label: 'D&D 5e',
+  sidebar: [
+    { type: 'bar', label: 'HP', bind: 'hp', icon: '/icons/enemy.png',
+      row_class: 'sb-hp-row', num_class: 'sb-hp-nums', fill_role: 'hp-fill',
+      cur: 'current', max: 'max', color: 'hp', temp: 'temp' },
+    { type: 'bar', label: 'XP', bind: 'xp', icon: '/icons/ability.png',
+      row_class: 'sb-xp-row', num_class: 'sb-xp-nums', fill_role: 'xp-fill',
+      fill_class: 'sb-xp-bar', cur: 'current', max: 'next', require_cur: true },
+    { type: 'stat_lines', lines: [
+      { label: 'AC', bind: 'ac' }, { label: 'Init', bind: 'initiative' },
+      { label: 'Spd', bind: 'speed' }, { label: 'HD', bind: 'hit_dice', format: 'hd' } ] },
+    { type: 'tag_list', bind: 'conditions' },
+    { type: 'tag_single', bind: 'concentration', prefix: '◈ ' },
+    { type: 'effects', bind: 'effects' },
+    { type: 'badge_set', bind: 'milestones' },
+    { type: 'pip_levels', bind: 'spell_slots' },
+    { type: 'feature_flags', flags: [ { label: '2nd Wind', bind: 'second_wind' } ] },
+    { type: 'badge', bind: 'inspiration', label: '✦ Inspiration' },
+  ],
+  sheet: {
+    combat_strip: [
+      { label: 'HP', bind: 'hp', format: 'ratio' },
+      { label: 'AC', bind: 'ac' },
+      { label: 'Init', bind: 'initiative' },
+      { label: 'Speed', bind: 'speed', suffix: ' ft' },
+      { label: 'Hit Dice', bind: 'hit_dice', format: 'hd' },
+    ],
+    stat_grid: { label: 'Ability Scores', bind: 'ability_scores', show_modifier: true,
+      stats: [ { key: 'str', label: 'STR' }, { key: 'dex', label: 'DEX' },
+        { key: 'con', label: 'CON' }, { key: 'int', label: 'INT' },
+        { key: 'wis', label: 'WIS' }, { key: 'cha', label: 'CHA' } ] },
+  },
+};
+
+function _gmManifest() {
+  const m = window.GM_UI_MANIFEST;
+  return (m && typeof m === 'object' && Array.isArray(m.sidebar)) ? m : DEFAULT_UI_MANIFEST;
+}
+
+// Resolve a dot-path ('hp', 'hp.current') against a player object.
+function _bind(p, path) {
+  if (!path) return undefined;
+  return String(path).split('.').reduce((o, k) => (o == null ? undefined : o[k]), p);
+}
+
+// ── Sidebar widget renderers (DOM/classes match the original hardcoded card) ──
+
+function _wBar(card, p, w) {
+  const obj = _bind(p, w.bind) || {};
+  const cur = obj[w.cur || 'current'];
+  const max = obj[w.max || 'max'];
+  if (w.require_cur && cur == null) return;
+  const row = document.createElement('div');
+  row.className = w.row_class || 'sb-hp-row';
+  const maxLabel = (w.max === 'next') ? (max ?? '?') : (max ?? '—');
+  row.innerHTML =
+    `${w.icon ? `<img src="${w.icon}" class="sb-row-icon" alt="">` : ''}<span class="sb-label">${w.label || ''}</span>
+    <span class="${w.num_class || 'sb-hp-nums'}">${cur ?? '—'} / ${maxLabel}</span>`;
+  card.appendChild(row);
+  const track = document.createElement('div');
+  track.className = 'sb-bar-track';
+  const fill = document.createElement('div');
+  fill.className = 'sb-bar-fill' + (w.fill_class ? ' ' + w.fill_class : '');
+  if (w.fill_role) fill.dataset.role = w.fill_role;
+  const pct = (max && cur != null) ? Math.max(0, Math.min(100, (cur / max) * 100))
+                                   : (w.color === 'hp' ? 100 : 0);
+  fill.style.width = pct + '%';
+  if (w.color === 'hp') fill.style.backgroundColor = _hpColor(pct);
+  track.appendChild(fill);
+  card.appendChild(track);
+  if (w.temp && obj[w.temp]) {
+    const tempEl = document.createElement('div');
+    tempEl.className = 'sb-hp-temp-row';
+    tempEl.dataset.role = 'hp-temp';
+    tempEl.textContent = '+' + obj[w.temp] + ' temp';
+    card.appendChild(tempEl);
+  }
+}
+
+function _wStatLines(card, p, w) {
+  const out = [];
+  (w.lines || []).forEach(ln => {
+    const v = _bind(p, ln.bind);
+    if (ln.format === 'hd') {
+      if (v) out.push(`${ln.label} <span class="val">${v.remaining ?? '?'}/${v.max ?? '?'} ${v.die || ''}</span>`);
+    } else if (v != null) {
+      out.push(`${ln.label} <span class="val">${v}</span>`);
+    }
+  });
+  if (!out.length) return;
+  const qs = document.createElement('div');
+  qs.className = 'sb-quick-stats';
+  qs.innerHTML = out.join('<br>');
+  card.appendChild(qs);
+}
+
+function _wTagList(card, p, w) {
+  const items = _bind(p, w.bind) || [];
+  const map = w.class_map || _DEFAULT_CONDITION_CLASS;
+  const el = document.createElement('div');
+  el.className = 'sb-conditions';
+  el.dataset.role = w.role || 'conditions';   // always appended (placeholder lets merges clear it)
+  items.forEach(c => {
+    const pill = document.createElement('span');
+    pill.className = `sb-condition-pill ${map[String(c).toLowerCase()] || 'info'}`;
+    pill.textContent = c;
+    el.appendChild(pill);
+  });
+  card.appendChild(el);
+}
+
+function _wTagSingle(card, p, w) {
+  const v = _bind(p, w.bind);
+  if (!v) return;
+  const el = document.createElement('div');
+  el.className = w.cls || 'sb-concentrate';
+  el.dataset.role = w.role || 'concentration';
+  el.textContent = (w.prefix || '') + v;
+  card.appendChild(el);
+}
+
+function _wEffects(card, p, w) {
+  const effects = _bind(p, w.bind) || [];
+  const el = document.createElement('div');
+  el.className = 'sb-effects';
+  el.dataset.role = 'effects';
+  effects.forEach(eff => el.appendChild(_makeEffectPill(eff, p.name)));
+  card.appendChild(el);
+}
+
+function _wBadgeSet(card, p, w) {
+  const ms = _bind(p, w.bind);
+  if (!ms || !Object.keys(ms).length) return;
+  const el = document.createElement('div');
+  el.className = 'sb-milestones';
+  el.dataset.role = w.role || 'milestones';
+  Object.entries(ms)
+    .filter(([_, count]) => count > 0)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .forEach(([label, count]) => {
+      const row = document.createElement('div'); row.className = 'sb-milestone-row';
+      const lbl = document.createElement('span'); lbl.className = 'sb-milestone-label'; lbl.textContent = label;
+      const pill = document.createElement('span'); pill.className = 'sb-milestone-count'; pill.textContent = count;
+      row.appendChild(lbl); row.appendChild(pill); el.appendChild(row);
+    });
+  if (el.children.length) card.appendChild(el);
+}
+
+function _wPipLevels(card, p, w) {
+  const slots = _bind(p, w.bind);
+  if (!slots || !Object.keys(slots).length) return;
+  const ROMAN = ['', 'I', 'II', 'III', 'IV', 'V', 'VI', 'VII', 'VIII', 'IX'];
+  const el = document.createElement('div');
+  el.className = 'sb-slots';
+  el.dataset.role = w.role || 'spell_slots';
+  Object.entries(slots).sort(([a], [b]) => +a - +b).forEach(([lvl, s]) => {
+    const max = s.max || 0;
+    if (!max) return;
+    const avail = max - (s.used || 0);
+    const row = document.createElement('div'); row.className = 'sb-slot-row';
+    const lbl = document.createElement('span'); lbl.className = 'sb-slot-level';
+    lbl.textContent = ROMAN[+lvl] || lvl; row.appendChild(lbl);
+    for (let i = 0; i < max; i++) {
+      const pip = document.createElement('span');
+      pip.className = 'sb-slot-pip ' + (i < avail ? 'avail' : 'spent');
+      row.appendChild(pip);
+    }
+    el.appendChild(row);
+  });
+  if (el.children.length) card.appendChild(el);
+}
+
+function _wFeatureFlags(card, p, w) {
+  const feats = [];
+  (w.flags || []).forEach(f => {
+    const v = _bind(p, f.bind);
+    if (v != null) feats.push(v ? `${f.label} ✓` : `${f.label} ✗`);
+  });
+  if (!feats.length) return;
+  const el = document.createElement('div');
+  el.className = 'sb-features';
+  el.dataset.role = 'features';
+  el.innerHTML = feats.map(f => {
+    const dim = f.endsWith('✗');
+    return `<span style="color:${dim ? 'rgba(200,185,150,0.25)' : 'rgba(140,190,140,0.6)'}">${f}</span>`;
+  }).join('<br>');
+  card.appendChild(el);
+}
+
+function _wBadge(card, p, w) {
+  if (!_bind(p, w.bind)) return;
+  const el = document.createElement('div');
+  el.className = w.cls || 'sb-inspiration';
+  el.dataset.role = w.role || 'inspiration';
+  el.textContent = w.label || '';
+  card.appendChild(el);
+}
+
+const _SIDEBAR_WIDGETS = {
+  bar: _wBar, stat_lines: _wStatLines, tag_list: _wTagList, tag_single: _wTagSingle,
+  effects: _wEffects, badge_set: _wBadgeSet, pip_levels: _wPipLevels,
+  feature_flags: _wFeatureFlags, badge: _wBadge,
+};
+
+function _renderSidebarWidget(card, p, w) {
+  const fn = w && _SIDEBAR_WIDGETS[w.type];
+  if (fn) { try { fn(card, p, w); } catch (e) { console.warn('[GM] widget render failed:', w && w.type, e); } }
+}
+
 function _buildPlayerCard(p, solo) {
   const card = document.createElement('div');
   card.className = 'sb-player';
@@ -4530,195 +4768,10 @@ function _buildPlayerCard(p, solo) {
     (subLine ? `<br><span style="opacity:0.7">${subLine}</span>` : '');
   card.appendChild(identEl);
 
-  // HP
-  const hp = p.hp || {};
-  const hpRow = document.createElement('div');
-  hpRow.className = 'sb-hp-row';
-  hpRow.innerHTML = `<img src="/icons/enemy.png" class="sb-row-icon" alt=""><span class="sb-label">HP</span>
-    <span class="sb-hp-nums">${hp.current ?? '—'} / ${hp.max ?? '—'}</span>`;
-  card.appendChild(hpRow);
-
-  const hpTrack = document.createElement('div');
-  hpTrack.className = 'sb-bar-track';
-  const hpFill = document.createElement('div');
-  hpFill.className = 'sb-bar-fill';
-  hpFill.dataset.role = 'hp-fill';
-  const hpPct = (hp.max && hp.current != null) ? Math.max(0, Math.min(100, (hp.current / hp.max) * 100)) : 100;
-  hpFill.style.width = hpPct + '%';
-  hpFill.style.backgroundColor = _hpColor(hpPct);
-  hpTrack.appendChild(hpFill);
-  card.appendChild(hpTrack);
-
-  if (hp.temp) {
-    const tempEl = document.createElement('div');
-    tempEl.className = 'sb-hp-temp-row';
-    tempEl.dataset.role = 'hp-temp';
-    tempEl.textContent = '+' + hp.temp + ' temp';
-    card.appendChild(tempEl);
-  }
-
-  // XP
-  const xp = p.xp || {};
-  if (xp.current != null) {
-    const xpRow = document.createElement('div');
-    xpRow.className = 'sb-xp-row';
-    xpRow.innerHTML = `<img src="/icons/ability.png" class="sb-row-icon" alt=""><span class="sb-label">XP</span>
-      <span class="sb-xp-nums">${xp.current} / ${xp.next ?? '?'}</span>`;
-    card.appendChild(xpRow);
-    const xpTrack = document.createElement('div');
-    xpTrack.className = 'sb-bar-track';
-    const xpFill = document.createElement('div');
-    xpFill.className = 'sb-bar-fill sb-xp-bar';
-    xpFill.dataset.role = 'xp-fill';
-    const xpPct = (xp.next && xp.current != null) ? Math.max(0, Math.min(100, (xp.current / xp.next) * 100)) : 0;
-    xpFill.style.width = xpPct + '%';
-    xpTrack.appendChild(xpFill);
-    card.appendChild(xpTrack);
-  }
-
-  // Quick combat stats
-  const quickLines = [];
-  if (p.ac        != null) quickLines.push(`AC <span class="val">${p.ac}</span>`);
-  if (p.initiative != null) quickLines.push(`Init <span class="val">${p.initiative}</span>`);
-  if (p.speed     != null) quickLines.push(`Spd <span class="val">${p.speed}</span>`);
-  if (p.hit_dice) {
-    const hd = p.hit_dice;
-    quickLines.push(`HD <span class="val">${hd.remaining ?? '?'}/${hd.max ?? '?'} ${hd.die || ''}</span>`);
-  }
-  if (quickLines.length) {
-    const qs = document.createElement('div');
-    qs.className = 'sb-quick-stats';
-    qs.innerHTML = quickLines.join('<br>');
-    card.appendChild(qs);
-  }
-
-  // Conditions
-  const CONDITION_CLASS = {
-    unconscious: 'danger', paralyzed: 'danger', petrified: 'danger', stunned: 'danger',
-    incapacitated: 'warn', frightened: 'warn', poisoned: 'warn', charmed: 'warn', exhausted: 'warn',
-    grappled: 'info', restrained: 'info', prone: 'info', blinded: 'info', deafened: 'info',
-    invisible: 'buff',
-  };
-  const conditions = p.conditions || [];
-  if (conditions.length) {
-    const condEl = document.createElement('div');
-    condEl.className = 'sb-conditions';
-    condEl.dataset.role = 'conditions';
-    conditions.forEach(c => {
-      const pill = document.createElement('span');
-      const cls  = CONDITION_CLASS[c.toLowerCase()] || 'info';
-      pill.className   = `sb-condition-pill ${cls}`;
-      pill.textContent = c;
-      condEl.appendChild(pill);
-    });
-    card.appendChild(condEl);
-  } else {
-    // Placeholder so merges can clear it
-    const condEl = document.createElement('div');
-    condEl.className = 'sb-conditions';
-    condEl.dataset.role = 'conditions';
-    card.appendChild(condEl);
-  }
-
-  // Concentration
-  if (p.concentration) {
-    const concEl = document.createElement('div');
-    concEl.className = 'sb-concentrate';
-    concEl.dataset.role = 'concentration';
-    concEl.textContent = `◈ ${p.concentration}`;
-    card.appendChild(concEl);
-  }
-
-  // Timed effects
-  {
-    const effects = p.effects || [];
-    const effEl = document.createElement('div');
-    effEl.className = 'sb-effects';
-    effEl.dataset.role = 'effects';
-    effects.forEach(eff => {
-      const pill = _makeEffectPill(eff, p.name);
-      effEl.appendChild(pill);
-    });
-    card.appendChild(effEl);
-  }
-
-  // Milestones (stack-based reward — Bardic Inspiration / Hero Coin / etc.).
-  // Distinct from the binary `inspiration` boolean badge handled elsewhere.
-  if (p.milestones && Object.keys(p.milestones).length) {
-    const msEl = document.createElement('div');
-    msEl.className = 'sb-milestones';
-    msEl.dataset.role = 'milestones';
-    Object.entries(p.milestones)
-      .filter(([_, count]) => count > 0)
-      .sort(([a], [b]) => a.localeCompare(b))
-      .forEach(([label, count]) => {
-        const row = document.createElement('div');
-        row.className = 'sb-milestone-row';
-        const lbl = document.createElement('span');
-        lbl.className = 'sb-milestone-label';
-        lbl.textContent = label;
-        const pill = document.createElement('span');
-        pill.className = 'sb-milestone-count';
-        pill.textContent = count;
-        row.appendChild(lbl);
-        row.appendChild(pill);
-        msEl.appendChild(row);
-      });
-    if (msEl.children.length) card.appendChild(msEl);
-  }
-
-  // Spell slots
-  if (p.spell_slots && Object.keys(p.spell_slots).length) {
-    const ROMAN = ['','I','II','III','IV','V','VI','VII','VIII','IX'];
-    const slotsEl = document.createElement('div');
-    slotsEl.className = 'sb-slots';
-    slotsEl.dataset.role = 'spell_slots';
-    Object.entries(p.spell_slots)
-      .sort(([a],[b]) => +a - +b)
-      .forEach(([lvl, s]) => {
-        const max = s.max || 0;
-        if (!max) return;
-        const avail = max - (s.used || 0);
-        const row = document.createElement('div');
-        row.className = 'sb-slot-row';
-        const lbl = document.createElement('span');
-        lbl.className = 'sb-slot-level';
-        lbl.textContent = ROMAN[+lvl] || lvl;
-        row.appendChild(lbl);
-        for (let i = 0; i < max; i++) {
-          const pip = document.createElement('span');
-          pip.className = 'sb-slot-pip ' + (i < avail ? 'avail' : 'spent');
-          row.appendChild(pip);
-        }
-        slotsEl.appendChild(row);
-      });
-    if (slotsEl.children.length) card.appendChild(slotsEl);
-  }
-
-  // Features (Second Wind etc)
-  const feats = [];
-  if (p.second_wind != null) {
-    feats.push(p.second_wind ? '2nd Wind ✓' : '2nd Wind ✗');
-  }
-  if (feats.length) {
-    const featEl = document.createElement('div');
-    featEl.className = 'sb-features';
-    featEl.dataset.role = 'features';
-    featEl.innerHTML = feats.map(f => {
-      const dim = f.endsWith('✗');
-      return `<span style="color:${dim ? 'rgba(200,185,150,0.25)' : 'rgba(140,190,140,0.6)'}">${f}</span>`;
-    }).join('<br>');
-    card.appendChild(featEl);
-  }
-
-  // Inspiration badge
-  if (p.inspiration) {
-    const badge = document.createElement('div');
-    badge.className = 'sb-inspiration';
-    badge.dataset.role = 'inspiration';
-    badge.textContent = '✦ Inspiration';
-    card.appendChild(badge);
-  }
+  // Stat widgets — driven by the active system's UI manifest (systems/<system>/ui.json
+  // -> window.GM_UI_MANIFEST), falling back to the built-in D&D 5e default.
+  // See systems/UI-MANIFEST.md. Each widget self-hides when its bound field is absent.
+  (_gmManifest().sidebar || []).forEach(w => _renderSidebarWidget(card, p, w));
 
   // Direct listener — belt-and-suspenders alongside the delegated sidebar listener
   card.addEventListener('click', function(e) {
@@ -4780,24 +4833,33 @@ function openSheet(name) {
   identEl.textContent = identParts.join('  ·  ') || '—';
   content.appendChild(identEl);
 
-  // Combat stats strip
-  const hp = p.hp || {};
-  const hd = p.hit_dice || {};
-  const stripData = [
-    ['HP',       hp.current != null ? `${hp.current}/${hp.max}` : '—'],
-    ['AC',       p.ac       ?? '—'],
-    ['Init',     p.initiative ?? '—'],
-    ['Speed',    p.speed    != null ? p.speed + ' ft' : '—'],
-    ['Hit Dice', hd.die     ? `${hd.remaining ?? '?'}/${hd.max ?? '?'} ${hd.die}` : '—'],
-  ];
-  if (hp.temp) stripData.splice(1, 0, ['Temp HP', '+' + hp.temp]);
+  // Combat stats strip — driven by the active system's manifest (sheet.combat_strip).
+  const _sheetMan = _gmManifest();
+  const _stripDef = (_sheetMan.sheet && _sheetMan.sheet.combat_strip)
+    || DEFAULT_UI_MANIFEST.sheet.combat_strip;
   const strip = document.createElement('div');
   strip.className = 'sm-combat-strip';
-  stripData.forEach(([label, val]) => {
+  const _stripCell = (label, val) => {
     const cell = document.createElement('div');
     cell.className = 'sm-stat-cell';
     cell.innerHTML = `<span class="sm-stat-label">${label}</span><span class="sm-stat-val">${val}</span>`;
     strip.appendChild(cell);
+  };
+  _stripDef.forEach(entry => {
+    const v = _bind(p, entry.bind);
+    let val = '—';
+    if (entry.format === 'ratio') {
+      val = (v && v.current != null) ? `${v.current}/${v.max}` : '—';
+    } else if (entry.format === 'hd') {
+      val = (v && v.die) ? `${v.remaining ?? '?'}/${v.max ?? '?'} ${v.die}` : '—';
+    } else if (v != null) {
+      val = v + (entry.suffix || '');
+    }
+    _stripCell(entry.label, val);
+    // Temp HP rides alongside the HP ratio cell, matching the original layout.
+    if (entry.format === 'ratio' && entry.bind === 'hp' && v && v.temp) {
+      _stripCell('Temp HP', '+' + v.temp);
+    }
   });
   content.appendChild(strip);
 
@@ -4808,22 +4870,30 @@ function openSheet(name) {
     content.appendChild(xpEl);
   }
 
-  // Ability scores (always shown in modal)
-  if (p.ability_scores) {
+  // Attribute grid — driven by the manifest (sheet.stat_grid). Handles both
+  // D&D-style {score, mod} entries (show_modifier) and pool-system raw ratings.
+  const _gridDef = (_sheetMan.sheet && _sheetMan.sheet.stat_grid)
+    || DEFAULT_UI_MANIFEST.sheet.stat_grid;
+  const _abils = _bind(p, _gridDef.bind || 'ability_scores');
+  if (_abils) {
     content.appendChild(_smDivider());
     const title = document.createElement('div');
     title.className = 'sm-section-title';
-    title.textContent = 'Ability Scores';
+    title.textContent = _gridDef.label || 'Ability Scores';
     content.appendChild(title);
     const grid = document.createElement('div');
     grid.className = 'sm-ab-grid';
-    ['str','dex','con','int','wis','cha'].forEach(key => {
-      const d = p.ability_scores[key] || {};
+    (_gridDef.stats || []).forEach(st => {
+      const raw = _abils[st.key];
+      const showMod = (st.show_modifier !== undefined) ? st.show_modifier : _gridDef.show_modifier;
+      let score, mod;
+      if (raw && typeof raw === 'object') { score = raw.score; mod = raw.mod; }
+      else { score = raw; }
       const cell = document.createElement('div');
       cell.className = 'sm-ab-cell';
-      cell.innerHTML = `<div class="sm-ab-name">${key.toUpperCase()}</div>
-        <div class="sm-ab-score">${d.score ?? '—'}</div>
-        <div class="sm-ab-mod">${d.mod ?? '—'}</div>`;
+      cell.innerHTML = `<div class="sm-ab-name">${st.label || String(st.key).toUpperCase()}</div>
+        <div class="sm-ab-score">${score ?? '—'}</div>` +
+        (showMod ? `<div class="sm-ab-mod">${mod ?? '—'}</div>` : '');
       grid.appendChild(cell);
     });
     content.appendChild(grid);

--- a/scripts/paths.py
+++ b/scripts/paths.py
@@ -120,6 +120,37 @@ def campaign_system_version(name: str, default: str = "") -> str:
     return m.group(1).strip()
 
 
+_SYSTEM_MODULE_PAT = _re.compile(
+    r"\*\*System Module:\*\*\s*([^\s|]+)", _re.IGNORECASE
+)
+
+
+def campaign_system(name: str, default: str = "dnd5e") -> str:
+    """Return the campaign's system *module* directory name, or `default` if unset.
+
+    Reads a `**System Module:** <name>` header line from state.md, where `<name>`
+    matches a directory under `systems/` (e.g. `dnd5e`, `shadowrun5e`). This is
+    deliberately distinct from the human-readable `**System:**` label some
+    campaigns carry (e.g. "D&D 5e") — that's for display, this is for resolution.
+    Campaigns predating the field fall back to `default`, so nothing breaks.
+
+    Also distinct from `campaign_system_version`, which returns the
+    edition/ruleset string (e.g. "2014"); this returns which module owns the
+    campaign.
+    """
+    state = find_campaign(name) / "state.md"
+    if not state.exists():
+        return default
+    try:
+        text = state.read_text(errors="replace")
+    except OSError:
+        return default
+    m = _SYSTEM_MODULE_PAT.search(text)
+    if not m:
+        return default
+    return m.group(1).strip()
+
+
 def system_data_path(system: str, version: str = "", filename: str = "") -> pathlib.Path:
     """Return a path under `systems/<system>/data/`.
 

--- a/systems/UI-MANIFEST.md
+++ b/systems/UI-MANIFEST.md
@@ -1,0 +1,197 @@
+# System UI manifest (`ui.json`)
+
+**Status: DRAFT proposal — not yet wired into the renderer.** This describes the
+contract that would let the display companion render a character sheet and stat
+sidebar for any game system without touching the front-end. It's the UI-layer
+companion to [`SYSTEM-PORTING.md`](../SYSTEM-PORTING.md), which covers the rules
+layer (`system.md`).
+
+## The design
+
+One renderer, many manifests. The display front-end (`display/templates/index.html`)
+stays a single generic renderer. Each system ships a small declarative
+`systems/<name>/ui.json` that says *what to show and how* — which stat widgets sit
+in the sidebar, what the primary resource looks like, what the character sheet
+contains. The renderer reads the manifest for the loaded campaign's system at
+startup and draws the sidebar from it.
+
+Why declarative-manifest instead of per-system HTML: shipping HTML/CSS per system
+fragments the front-end and forces every contributor to write display code. A
+manifest means a new system is a ~40-line JSON file, and the renderer stays one
+place to maintain. This is the realization of `SYSTEM-PORTING.md`'s "describe your
+primary resource and we map it to the display" instruction — `ui.json` *is* that map.
+
+## Resolution and fallback
+
+1. Server resolves the active campaign's system (it already knows this via
+   `paths.campaign_system_version`).
+2. If `systems/<system>/ui.json` exists, the renderer uses it.
+3. If it doesn't, the renderer uses a built-in **default manifest** (see below), so
+   a system with no UI file still renders something sane. Authoring `ui.json` is an
+   upgrade, never a prerequisite for a system to work.
+
+**Self-hiding widgets:** every widget renders nothing when its bound data field is
+absent or empty. So the manifest is the *superset* of what can appear — a D&D
+caster with no spell slots pushed simply shows no slot widget. A system that never
+pushes `spell_slots` never shows it. This is what makes one renderer safe across
+systems: the manifest declares capacity, the pushed data decides what's drawn.
+
+## Top-level shape
+
+```jsonc
+{
+  "manifest_version": 1,
+  "system": "dnd5e",          // must match the systems/<dir> name
+  "label": "D&D 5e",          // human label (sidebar badge, etc.)
+  "sidebar": [ <widget>, ... ],   // ordered, top to bottom
+  "sheet": {                       // the click-to-open character sheet modal
+    "stat_grid": <stat_grid>,
+    "sections": [ <section>, ... ]
+  },
+  "vocab": {                       // optional affordances/validation hints
+    "conditions": [ "...", ... ],
+    "sustained_term": "Concentration"
+  }
+}
+```
+
+## Widget catalog (the `sidebar` primitives)
+
+Every widget has `type`, `label`, and `bind` (a key in the pushed player object;
+dot-paths like `sheet.abilities` are allowed). Type-specific options follow.
+
+| `type` | Renders | Binds to (shape) | Options |
+|--------|---------|------------------|---------|
+| `bar` | Horizontal fill bar | `{current, max, temp?}` | `color` |
+| `counter` | `value / goal` inline numeric | `{current, next}` (keys configurable via `fields`) | `fields` |
+| `pip_track` | One row of pips draining from max | `{remaining\|current, max}` **or** a boolean (→ 1 pip, filled when true) | `pip_color`, `boolean` |
+| `pip_levels` | Grouped pip rows keyed by level/category | `{ "<level>": {used, max}, ... }` | `pip_color` |
+| `tag_list` | List of named tags | `[ "name", ... ]` | — |
+| `tag_single` | One highlighted tag (or hidden if empty) | `string \| null` | `color` |
+| `badge_set` | Labeled count badges (the generic milestone map) | `{ "<label>": count }` (+ optional `milestone_caps`) | — |
+
+Notes:
+- `pip_track` is the generalization of D&D's Second Wind (boolean) and Hit Dice
+  (pool), and the home for things like Shadowrun **Edge** or Cyberpunk **Luck**.
+- `pip_levels` is the generalization of D&D **spell slots**. Systems without
+  level-banded resources just don't use it.
+- `badge_set` is already system-agnostic in the backend today — `milestones` is a
+  free `{label: count}` map with per-label caps (`milestone_caps`) and generic
+  award/spend events. It's the model the rest of this schema follows: Inspiration,
+  Bennie, Hero Point, Edge, Fate Point all ride the same widget.
+
+## Sheet: `stat_grid` and `sections`
+
+```jsonc
+"stat_grid": {
+  "label": "Ability Scores",
+  "bind": "sheet.abilities",            // { "STR": 16, "DEX": 14, ... }
+  "stats": [
+    { "key": "STR", "label": "STR", "show_modifier": true },
+    ...
+  ]
+}
+```
+
+`show_modifier: true` renders the score plus a derived 5e-style modifier
+(`(score-10)/2`). `show_modifier: false` renders the value directly — which is the
+right behavior for dice-pool systems where the stat *is* the rating (Shadowrun,
+VtM, Wrath & Glory). This is the UI side of `SYSTEM-PORTING.md`'s
+"is there a modifier conversion?" question.
+
+```jsonc
+"sections": [
+  { "type": "attacks",   "label": "Attacks",   "bind": "sheet.attacks" },
+  { "type": "spells",    "label": "Spells",    "bind": "sheet.spells" },
+  { "type": "features",  "label": "Features",  "bind": "sheet.features" },
+  { "type": "inventory", "label": "Inventory", "bind": "sheet.inventory" },
+  { "type": "generic_list", "label": "Qualities", "bind": "sheet.qualities" }
+]
+```
+
+`generic_list` is the escape hatch for system-specific sheet content that doesn't
+map to the built-in section types — renders a labeled list of strings (or
+`{name, detail}` objects) so a system can show whatever it needs without a new
+renderer.
+
+## The default manifest (no `ui.json` present)
+
+```jsonc
+{
+  "manifest_version": 1,
+  "system": "<resolved>",
+  "label": "<resolved>",
+  "sidebar": [
+    { "type": "bar",       "label": "HP",         "bind": "hp",         "color": "#b5524a" },
+    { "type": "counter",   "label": "XP",         "bind": "xp" },
+    { "type": "tag_list",  "label": "Conditions", "bind": "conditions" },
+    { "type": "tag_single","label": "Sustained",  "bind": "concentration" },
+    { "type": "badge_set", "label": "Resources",  "bind": "milestones" }
+  ],
+  "sheet": {
+    "stat_grid": { "label": "Stats", "bind": "sheet.abilities", "stats": [], "show_modifier": false },
+    "sections": [
+      { "type": "attacks",   "label": "Attacks",   "bind": "sheet.attacks" },
+      { "type": "features",  "label": "Features",  "bind": "sheet.features" },
+      { "type": "inventory", "label": "Inventory", "bind": "sheet.inventory" }
+    ]
+  }
+}
+```
+
+With an empty `stats` array the grid renders whatever keys appear in
+`sheet.abilities`, so even an unconfigured system shows its attributes.
+
+## Illustrative target — Shadowrun 5e (not a real file yet)
+
+Shown here so the shape is concrete for the SR port. Edge becomes a `pip_track`,
+attributes render as raw ratings (`show_modifier: false`), the SR condition
+monitors map to two `pip_track`s, and SR's "sustaining a spell" reuses `tag_single`.
+
+```jsonc
+{
+  "manifest_version": 1,
+  "system": "shadowrun5e",
+  "label": "Shadowrun 5e",
+  "sidebar": [
+    { "type": "pip_track", "label": "Physical",  "bind": "physical_monitor", "pip_color": "#b5524a" },
+    { "type": "pip_track", "label": "Stun",      "bind": "stun_monitor",     "pip_color": "#5a7fb5" },
+    { "type": "pip_track", "label": "Edge",      "bind": "edge",             "pip_color": "#c9a24b" },
+    { "type": "tag_list",   "label": "Status",    "bind": "conditions" },
+    { "type": "tag_single", "label": "Sustaining","bind": "sustaining" },
+    { "type": "badge_set",  "label": "Resources", "bind": "milestones" }
+  ],
+  "sheet": {
+    "stat_grid": {
+      "label": "Attributes",
+      "bind": "sheet.attributes",
+      "stats": [
+        { "key": "BOD", "label": "BOD", "show_modifier": false },
+        { "key": "AGI", "label": "AGI", "show_modifier": false },
+        { "key": "REA", "label": "REA", "show_modifier": false },
+        { "key": "STR", "label": "STR", "show_modifier": false },
+        { "key": "WIL", "label": "WIL", "show_modifier": false },
+        { "key": "LOG", "label": "LOG", "show_modifier": false },
+        { "key": "INT", "label": "INT", "show_modifier": false },
+        { "key": "CHA", "label": "CHA", "show_modifier": false }
+      ]
+    },
+    "sections": [
+      { "type": "generic_list", "label": "Qualities", "bind": "sheet.qualities" },
+      { "type": "generic_list", "label": "Gear",      "bind": "sheet.gear" },
+      { "type": "spells",       "label": "Spells",    "bind": "sheet.spells" }
+    ]
+  }
+}
+```
+
+## Open questions for the renderer PR
+
+- **`sheet.abilities` binding** — confirm where ability/attribute scores actually
+  live in the pushed `sheet` object today; the dnd5e reference assumes
+  `sheet.abilities`. (`push_stats.py --sheet` documents `attacks/spells/features/inventory`
+  but not the ability block, so this needs a look at the sheet-modal render path.)
+- **Faction / quest / turn-order panels** stay global (system-agnostic already) and
+  are out of scope for `ui.json`.
+- **Colors** are passed through as-is; consider a small named palette so manifests
+  don't hardcode hex if we want theme-awareness later.

--- a/systems/UI-MANIFEST.md
+++ b/systems/UI-MANIFEST.md
@@ -1,40 +1,45 @@
 # System UI manifest (`ui.json`)
 
-**Status: DRAFT proposal — not yet wired into the renderer.** This describes the
-contract that would let the display companion render a character sheet and stat
-sidebar for any game system without touching the front-end. It's the UI-layer
-companion to [`SYSTEM-PORTING.md`](../SYSTEM-PORTING.md), which covers the rules
-layer (`system.md`).
+Lets the display companion render a character sidebar and sheet for any game
+system without touching the front-end. It's the UI-layer companion to
+[`SYSTEM-PORTING.md`](../SYSTEM-PORTING.md) (the rules layer, `system.md`).
 
 ## The design
 
-One renderer, many manifests. The display front-end (`display/templates/index.html`)
-stays a single generic renderer. Each system ships a small declarative
-`systems/<name>/ui.json` that says *what to show and how* — which stat widgets sit
-in the sidebar, what the primary resource looks like, what the character sheet
-contains. The renderer reads the manifest for the loaded campaign's system at
-startup and draws the sidebar from it.
+One renderer, many manifests. The front-end (`display/templates/index.html`) is a
+single generic renderer. Each system ships a small declarative
+`systems/<name>/ui.json` describing *what to show* — which stat widgets sit in the
+sidebar, what the combat strip and attribute grid contain. The renderer reads the
+manifest for the loaded campaign's system and draws from it.
 
-Why declarative-manifest instead of per-system HTML: shipping HTML/CSS per system
+Why declarative manifest instead of per-system HTML: shipping HTML/CSS per system
 fragments the front-end and forces every contributor to write display code. A
-manifest means a new system is a ~40-line JSON file, and the renderer stays one
-place to maintain. This is the realization of `SYSTEM-PORTING.md`'s "describe your
-primary resource and we map it to the display" instruction — `ui.json` *is* that map.
+manifest makes a new system a ~40-line JSON file, and the renderer stays one place
+to maintain.
 
 ## Resolution and fallback
 
-1. Server resolves the active campaign's system (it already knows this via
-   `paths.campaign_system_version`).
-2. If `systems/<system>/ui.json` exists, the renderer uses it.
-3. If it doesn't, the renderer uses a built-in **default manifest** (see below), so
-   a system with no UI file still renders something sane. Authoring `ui.json` is an
-   upgrade, never a prerequisite for a system to work.
+1. A campaign declares its system module in `state.md`:
+   `**System Module:** <name>` (e.g. `dnd5e`, `shadowrun5e`). This is distinct
+   from the human-readable `**System:**` label some campaigns carry ("D&D 5e") —
+   that's for display, `**System Module:**` is for resolution. Campaigns without
+   the field default to `dnd5e`.
+2. The server (`_load_ui_manifest`) reads `systems/<module>/ui.json` and injects it
+   into the page as `window.GM_UI_MANIFEST`.
+3. If there's no campaign, no `ui.json`, or the file is invalid, it injects `null`
+   and the renderer falls back to its **built-in default manifest** — which
+   reproduces the D&D 5e layout exactly. So the display renders identically with or
+   without a manifest file; authoring one is an upgrade, never a prerequisite.
 
-**Self-hiding widgets:** every widget renders nothing when its bound data field is
-absent or empty. So the manifest is the *superset* of what can appear — a D&D
-caster with no spell slots pushed simply shows no slot widget. A system that never
-pushes `spell_slots` never shows it. This is what makes one renderer safe across
-systems: the manifest declares capacity, the pushed data decides what's drawn.
+Resolved at page render. Switching systems takes effect on the next display load,
+and the display is force-restarted each session, so this is a non-issue in normal
+use.
+
+**Self-hiding widgets:** every widget renders nothing when its bound field is
+absent or empty. So the manifest declares the *superset* of what can appear, and
+the pushed stats decide what's actually drawn — a D&D caster with no spell slots
+pushed simply shows no slot widget; a system that never pushes `spell_slots` never
+shows it.
 
 ## Top-level shape
 
@@ -42,111 +47,79 @@ systems: the manifest declares capacity, the pushed data decides what's drawn.
 {
   "manifest_version": 1,
   "system": "dnd5e",          // must match the systems/<dir> name
-  "label": "D&D 5e",          // human label (sidebar badge, etc.)
-  "sidebar": [ <widget>, ... ],   // ordered, top to bottom
-  "sheet": {                       // the click-to-open character sheet modal
-    "stat_grid": <stat_grid>,
-    "sections": [ <section>, ... ]
-  },
-  "vocab": {                       // optional affordances/validation hints
-    "conditions": [ "...", ... ],
-    "sustained_term": "Concentration"
+  "label": "D&D 5e",          // human label
+  "sidebar": [ <widget>, ... ],    // ordered, top to bottom under the name/identity header
+  "sheet": {
+    "combat_strip": [ <cell>, ... ],   // the stat row at the top of the sheet modal
+    "stat_grid": <stat_grid>           // the attribute grid
   }
 }
 ```
 
-## Widget catalog (the `sidebar` primitives)
+The card's name / race·class·level / background header is universal and rendered
+for every system (fields self-hide when empty), so it isn't in the manifest.
+Faction, quest, and turn-order panels are global and system-agnostic — also out of
+scope for `ui.json`.
 
-Every widget has `type`, `label`, and `bind` (a key in the pushed player object;
-dot-paths like `sheet.abilities` are allowed). Type-specific options follow.
+## Sidebar widget catalog
 
-| `type` | Renders | Binds to (shape) | Options |
-|--------|---------|------------------|---------|
-| `bar` | Horizontal fill bar | `{current, max, temp?}` | `color` |
-| `counter` | `value / goal` inline numeric | `{current, next}` (keys configurable via `fields`) | `fields` |
-| `pip_track` | One row of pips draining from max | `{remaining\|current, max}` **or** a boolean (→ 1 pip, filled when true) | `pip_color`, `boolean` |
-| `pip_levels` | Grouped pip rows keyed by level/category | `{ "<level>": {used, max}, ... }` | `pip_color` |
-| `tag_list` | List of named tags | `[ "name", ... ]` | — |
-| `tag_single` | One highlighted tag (or hidden if empty) | `string \| null` | `color` |
-| `badge_set` | Labeled count badges (the generic milestone map) | `{ "<label>": count }` (+ optional `milestone_caps`) | — |
+Each widget has a `type` plus a `bind` (a key in the pushed player object;
+dot-paths like `hp.current` work). The data shapes below are what the player object
+carries (see `display/push_stats.py`).
+
+| `type` | Renders | Binds to (shape) | Key options |
+|--------|---------|------------------|-------------|
+| `bar` | Labelled value + fill bar | `{current, max, temp?}` | `cur`,`max` (field names), `color:"hp"` for HP's dynamic colour, `temp`, `icon`, `fill_class`, `require_cur` (only draw when current present) |
+| `stat_lines` | Inline `Label value` lines | each line binds a scalar | `lines:[{label,bind,format?}]`; `format:"hd"` reads `{remaining,max,die}` |
+| `tag_list` | List of tags | `[ "name", ... ]` | `class_map` (tag → severity class: `danger`/`warn`/`info`/`buff`) |
+| `tag_single` | One tag, or hidden if empty | `string \| null` | `prefix` (e.g. `"◈ "`) |
+| `effects` | Timed-effect pills | `[ effect, ... ]` | — (uses the built-in effect-pill renderer) |
+| `badge_set` | Labelled count badges | `{ "<label>": count }` | — (the generic milestone map: Inspiration / Edge / Bennie / Fate Point all ride this) |
+| `pip_levels` | Pip rows grouped by level | `{ "<level>": {used, max}, ... }` | — (D&D spell slots; any level-banded resource) |
+| `feature_flags` | Boolean ✓/✗ lines | each flag binds a boolean | `flags:[{label,bind}]` |
+| `badge` | A single badge, shown when truthy | boolean | `label` |
 
 Notes:
-- `pip_track` is the generalization of D&D's Second Wind (boolean) and Hit Dice
-  (pool), and the home for things like Shadowrun **Edge** or Cyberpunk **Luck**.
-- `pip_levels` is the generalization of D&D **spell slots**. Systems without
-  level-banded resources just don't use it.
-- `badge_set` is already system-agnostic in the backend today — `milestones` is a
-  free `{label: count}` map with per-label caps (`milestone_caps`) and generic
-  award/spend events. It's the model the rest of this schema follows: Inspiration,
-  Bennie, Hero Point, Edge, Fate Point all ride the same widget.
+- `bar` covers HP (dynamic colour via `color:"hp"`, `temp` row) and XP (`max:"next"`,
+  `require_cur:true`).
+- For a **single-pool resource** like Shadowrun Edge or Cyberpunk Luck, use a `bar`
+  (`{current,max}`) or model it as a level-1 `pip_levels`/`badge_set` entry,
+  whichever reads better.
+- `badge_set` is already system-agnostic in the backend (`milestones` is a free
+  `{label:count}` map with per-label caps and generic award/spend events).
 
-## Sheet: `stat_grid` and `sections`
+## Sheet: `combat_strip` and `stat_grid`
+
+```jsonc
+"combat_strip": [
+  { "label": "HP",        "bind": "hp",        "format": "ratio" },   // {current,max}; a Temp HP cell auto-follows when hp.temp is set
+  { "label": "AC",        "bind": "ac" },
+  { "label": "Speed",     "bind": "speed",     "suffix": " ft" },
+  { "label": "Hit Dice",  "bind": "hit_dice",  "format": "hd" }       // {remaining,max,die}
+]
+```
+Cell `format`: `"ratio"` → `current/max`; `"hd"` → `remaining/max die`; omitted →
+the raw value plus optional `suffix`. Missing data renders `—`.
 
 ```jsonc
 "stat_grid": {
   "label": "Ability Scores",
-  "bind": "sheet.abilities",            // { "STR": 16, "DEX": 14, ... }
-  "stats": [
-    { "key": "STR", "label": "STR", "show_modifier": true },
-    ...
-  ]
+  "bind": "ability_scores",          // { "str": {score, mod}, ... }  OR  { "BOD": 5, ... } for raw ratings
+  "show_modifier": true,             // D&D: show derived modifier under the score
+  "stats": [ { "key": "str", "label": "STR" }, ... ]
 }
 ```
+Each `stats` entry maps a key in the bound object to a labelled cell. Per-entry
+`show_modifier` overrides the grid default. With `show_modifier:false` the cell
+shows the value directly — the right behaviour for dice-pool systems where the stat
+*is* the rating (Shadowrun, VtM, Wrath & Glory). The renderer accepts both a
+`{score, mod}` object (D&D) and a plain number (raw ratings) per key.
 
-`show_modifier: true` renders the score plus a derived 5e-style modifier
-(`(score-10)/2`). `show_modifier: false` renders the value directly — which is the
-right behavior for dice-pool systems where the stat *is* the rating (Shadowrun,
-VtM, Wrath & Glory). This is the UI side of `SYSTEM-PORTING.md`'s
-"is there a modifier conversion?" question.
+The rest of the sheet modal (attacks / spells / features / inventory /
+relationships) is already field-driven and self-hiding — it renders whatever the
+pushed `sheet` object contains, for any system, no manifest needed.
 
-```jsonc
-"sections": [
-  { "type": "attacks",   "label": "Attacks",   "bind": "sheet.attacks" },
-  { "type": "spells",    "label": "Spells",    "bind": "sheet.spells" },
-  { "type": "features",  "label": "Features",  "bind": "sheet.features" },
-  { "type": "inventory", "label": "Inventory", "bind": "sheet.inventory" },
-  { "type": "generic_list", "label": "Qualities", "bind": "sheet.qualities" }
-]
-```
-
-`generic_list` is the escape hatch for system-specific sheet content that doesn't
-map to the built-in section types — renders a labeled list of strings (or
-`{name, detail}` objects) so a system can show whatever it needs without a new
-renderer.
-
-## The default manifest (no `ui.json` present)
-
-```jsonc
-{
-  "manifest_version": 1,
-  "system": "<resolved>",
-  "label": "<resolved>",
-  "sidebar": [
-    { "type": "bar",       "label": "HP",         "bind": "hp",         "color": "#b5524a" },
-    { "type": "counter",   "label": "XP",         "bind": "xp" },
-    { "type": "tag_list",  "label": "Conditions", "bind": "conditions" },
-    { "type": "tag_single","label": "Sustained",  "bind": "concentration" },
-    { "type": "badge_set", "label": "Resources",  "bind": "milestones" }
-  ],
-  "sheet": {
-    "stat_grid": { "label": "Stats", "bind": "sheet.abilities", "stats": [], "show_modifier": false },
-    "sections": [
-      { "type": "attacks",   "label": "Attacks",   "bind": "sheet.attacks" },
-      { "type": "features",  "label": "Features",  "bind": "sheet.features" },
-      { "type": "inventory", "label": "Inventory", "bind": "sheet.inventory" }
-    ]
-  }
-}
-```
-
-With an empty `stats` array the grid renders whatever keys appear in
-`sheet.abilities`, so even an unconfigured system shows its attributes.
-
-## Illustrative target — Shadowrun 5e (not a real file yet)
-
-Shown here so the shape is concrete for the SR port. Edge becomes a `pip_track`,
-attributes render as raw ratings (`show_modifier: false`), the SR condition
-monitors map to two `pip_track`s, and SR's "sustaining a spell" reuses `tag_single`.
+## Illustrative target — Shadowrun 5e
 
 ```jsonc
 {
@@ -154,44 +127,46 @@ monitors map to two `pip_track`s, and SR's "sustaining a spell" reuses `tag_sing
   "system": "shadowrun5e",
   "label": "Shadowrun 5e",
   "sidebar": [
-    { "type": "pip_track", "label": "Physical",  "bind": "physical_monitor", "pip_color": "#b5524a" },
-    { "type": "pip_track", "label": "Stun",      "bind": "stun_monitor",     "pip_color": "#5a7fb5" },
-    { "type": "pip_track", "label": "Edge",      "bind": "edge",             "pip_color": "#c9a24b" },
-    { "type": "tag_list",   "label": "Status",    "bind": "conditions" },
-    { "type": "tag_single", "label": "Sustaining","bind": "sustaining" },
-    { "type": "badge_set",  "label": "Resources", "bind": "milestones" }
+    { "type": "bar", "label": "Physical", "bind": "physical_monitor", "cur": "current", "max": "max" },
+    { "type": "bar", "label": "Stun",     "bind": "stun_monitor",     "cur": "current", "max": "max" },
+    { "type": "bar", "label": "Edge",     "bind": "edge",             "cur": "current", "max": "max", "require_cur": true },
+    { "type": "stat_lines", "lines": [
+      { "label": "Init",    "bind": "initiative" },
+      { "label": "Phys Lim","bind": "physical_limit" },
+      { "label": "Ment Lim","bind": "mental_limit" } ] },
+    { "type": "tag_list",   "bind": "conditions" },
+    { "type": "tag_single", "bind": "sustaining", "prefix": "◈ " },
+    { "type": "effects",    "bind": "effects" },
+    { "type": "badge_set",  "bind": "milestones" }
   ],
   "sheet": {
+    "combat_strip": [
+      { "label": "Physical", "bind": "physical_monitor", "format": "ratio" },
+      { "label": "Stun",     "bind": "stun_monitor",     "format": "ratio" },
+      { "label": "Edge",     "bind": "edge",             "format": "ratio" },
+      { "label": "Init",     "bind": "initiative" }
+    ],
     "stat_grid": {
       "label": "Attributes",
-      "bind": "sheet.attributes",
+      "bind": "ability_scores",
+      "show_modifier": false,
       "stats": [
-        { "key": "BOD", "label": "BOD", "show_modifier": false },
-        { "key": "AGI", "label": "AGI", "show_modifier": false },
-        { "key": "REA", "label": "REA", "show_modifier": false },
-        { "key": "STR", "label": "STR", "show_modifier": false },
-        { "key": "WIL", "label": "WIL", "show_modifier": false },
-        { "key": "LOG", "label": "LOG", "show_modifier": false },
-        { "key": "INT", "label": "INT", "show_modifier": false },
-        { "key": "CHA", "label": "CHA", "show_modifier": false }
+        { "key": "BOD", "label": "BOD" }, { "key": "AGI", "label": "AGI" },
+        { "key": "REA", "label": "REA" }, { "key": "STR", "label": "STR" },
+        { "key": "WIL", "label": "WIL" }, { "key": "LOG", "label": "LOG" },
+        { "key": "INT", "label": "INT" }, { "key": "CHA", "label": "CHA" }
       ]
-    },
-    "sections": [
-      { "type": "generic_list", "label": "Qualities", "bind": "sheet.qualities" },
-      { "type": "generic_list", "label": "Gear",      "bind": "sheet.gear" },
-      { "type": "spells",       "label": "Spells",    "bind": "sheet.spells" }
-    ]
+    }
   }
 }
 ```
 
-## Open questions for the renderer PR
+The SR system module pushes the matching fields (`physical_monitor`, `edge`,
+`ability_scores` as raw ratings, etc.) when it sends stats, and declares
+`**System Module:** shadowrun5e` in the campaign's `state.md`. Everything else —
+the renderer, the feed, dice, turn order — is untouched.
 
-- **`sheet.abilities` binding** — confirm where ability/attribute scores actually
-  live in the pushed `sheet` object today; the dnd5e reference assumes
-  `sheet.abilities`. (`push_stats.py --sheet` documents `attacks/spells/features/inventory`
-  but not the ability block, so this needs a look at the sheet-modal render path.)
-- **Faction / quest / turn-order panels** stay global (system-agnostic already) and
-  are out of scope for `ui.json`.
-- **Colors** are passed through as-is; consider a small named palette so manifests
-  don't hardcode hex if we want theme-awareness later.
+## Reference
+
+`systems/dnd5e/ui.json` is the working reference manifest; it mirrors the renderer's
+built-in default exactly and reproduces the original D&D 5e display.

--- a/systems/dnd5e/ui.json
+++ b/systems/dnd5e/ui.json
@@ -3,87 +3,59 @@
   "system": "dnd5e",
   "label": "D&D 5e",
 
-  "_comment": "DRAFT reference manifest — reproduces the current hardcoded D&D display. Not yet read by the renderer; see systems/UI-MANIFEST.md. Every widget self-hides when its bound field is absent, so non-casters show no spell slots, etc.",
+  "_comment": "Reference manifest. Mirrors the renderer's built-in default exactly, so it reproduces the original hardcoded D&D 5e display. Widgets self-hide when their bound field is absent (a non-caster shows no spell slots, etc.). See systems/UI-MANIFEST.md for the widget catalog.",
 
   "sidebar": [
-    {
-      "type": "bar",
-      "label": "HP",
-      "bind": "hp",
-      "fields": { "current": "current", "max": "max", "temp": "temp" },
-      "color": "#b5524a"
-    },
-    {
-      "type": "counter",
-      "label": "XP",
-      "bind": "xp",
-      "fields": { "current": "current", "next": "next" }
-    },
-    {
-      "type": "pip_track",
-      "label": "Hit Dice",
-      "bind": "hit_dice",
-      "fields": { "current": "remaining", "max": "max" },
-      "pip_color": "#c9a24b"
-    },
-    {
-      "type": "pip_track",
-      "label": "Second Wind",
-      "bind": "second_wind",
-      "boolean": true,
-      "pip_color": "#c9a24b"
-    },
-    {
-      "type": "pip_levels",
-      "label": "Spell Slots",
-      "bind": "spell_slots",
-      "pip_color": "#a078dc"
-    },
-    {
-      "type": "tag_list",
-      "label": "Conditions",
-      "bind": "conditions"
-    },
-    {
-      "type": "tag_single",
-      "label": "Concentrating",
-      "bind": "concentration",
-      "color": "#a078dc"
-    },
-    {
-      "type": "badge_set",
-      "label": "Resources",
-      "bind": "milestones"
-    }
+    { "type": "bar", "label": "HP", "bind": "hp", "icon": "/icons/enemy.png",
+      "row_class": "sb-hp-row", "num_class": "sb-hp-nums", "fill_role": "hp-fill",
+      "cur": "current", "max": "max", "color": "hp", "temp": "temp" },
+
+    { "type": "bar", "label": "XP", "bind": "xp", "icon": "/icons/ability.png",
+      "row_class": "sb-xp-row", "num_class": "sb-xp-nums", "fill_role": "xp-fill",
+      "fill_class": "sb-xp-bar", "cur": "current", "max": "next", "require_cur": true },
+
+    { "type": "stat_lines", "lines": [
+      { "label": "AC", "bind": "ac" },
+      { "label": "Init", "bind": "initiative" },
+      { "label": "Spd", "bind": "speed" },
+      { "label": "HD", "bind": "hit_dice", "format": "hd" }
+    ] },
+
+    { "type": "tag_list", "bind": "conditions" },
+
+    { "type": "tag_single", "bind": "concentration", "prefix": "◈ " },
+
+    { "type": "effects", "bind": "effects" },
+
+    { "type": "badge_set", "bind": "milestones" },
+
+    { "type": "pip_levels", "bind": "spell_slots" },
+
+    { "type": "feature_flags", "flags": [ { "label": "2nd Wind", "bind": "second_wind" } ] },
+
+    { "type": "badge", "bind": "inspiration", "label": "✦ Inspiration" }
   ],
 
   "sheet": {
+    "combat_strip": [
+      { "label": "HP", "bind": "hp", "format": "ratio" },
+      { "label": "AC", "bind": "ac" },
+      { "label": "Init", "bind": "initiative" },
+      { "label": "Speed", "bind": "speed", "suffix": " ft" },
+      { "label": "Hit Dice", "bind": "hit_dice", "format": "hd" }
+    ],
     "stat_grid": {
       "label": "Ability Scores",
-      "bind": "sheet.abilities",
+      "bind": "ability_scores",
+      "show_modifier": true,
       "stats": [
-        { "key": "STR", "label": "STR", "show_modifier": true },
-        { "key": "DEX", "label": "DEX", "show_modifier": true },
-        { "key": "CON", "label": "CON", "show_modifier": true },
-        { "key": "INT", "label": "INT", "show_modifier": true },
-        { "key": "WIS", "label": "WIS", "show_modifier": true },
-        { "key": "CHA", "label": "CHA", "show_modifier": true }
+        { "key": "str", "label": "STR" },
+        { "key": "dex", "label": "DEX" },
+        { "key": "con", "label": "CON" },
+        { "key": "int", "label": "INT" },
+        { "key": "wis", "label": "WIS" },
+        { "key": "cha", "label": "CHA" }
       ]
-    },
-    "sections": [
-      { "type": "attacks",   "label": "Attacks",   "bind": "sheet.attacks" },
-      { "type": "spells",    "label": "Spells",    "bind": "sheet.spells" },
-      { "type": "features",  "label": "Features",  "bind": "sheet.features" },
-      { "type": "inventory", "label": "Inventory", "bind": "sheet.inventory" }
-    ]
-  },
-
-  "vocab": {
-    "conditions": [
-      "Blinded", "Charmed", "Deafened", "Frightened", "Grappled",
-      "Incapacitated", "Invisible", "Paralyzed", "Petrified", "Poisoned",
-      "Prone", "Restrained", "Stunned", "Unconscious", "Exhaustion"
-    ],
-    "sustained_term": "Concentration"
+    }
   }
 }

--- a/systems/dnd5e/ui.json
+++ b/systems/dnd5e/ui.json
@@ -1,0 +1,89 @@
+{
+  "manifest_version": 1,
+  "system": "dnd5e",
+  "label": "D&D 5e",
+
+  "_comment": "DRAFT reference manifest — reproduces the current hardcoded D&D display. Not yet read by the renderer; see systems/UI-MANIFEST.md. Every widget self-hides when its bound field is absent, so non-casters show no spell slots, etc.",
+
+  "sidebar": [
+    {
+      "type": "bar",
+      "label": "HP",
+      "bind": "hp",
+      "fields": { "current": "current", "max": "max", "temp": "temp" },
+      "color": "#b5524a"
+    },
+    {
+      "type": "counter",
+      "label": "XP",
+      "bind": "xp",
+      "fields": { "current": "current", "next": "next" }
+    },
+    {
+      "type": "pip_track",
+      "label": "Hit Dice",
+      "bind": "hit_dice",
+      "fields": { "current": "remaining", "max": "max" },
+      "pip_color": "#c9a24b"
+    },
+    {
+      "type": "pip_track",
+      "label": "Second Wind",
+      "bind": "second_wind",
+      "boolean": true,
+      "pip_color": "#c9a24b"
+    },
+    {
+      "type": "pip_levels",
+      "label": "Spell Slots",
+      "bind": "spell_slots",
+      "pip_color": "#a078dc"
+    },
+    {
+      "type": "tag_list",
+      "label": "Conditions",
+      "bind": "conditions"
+    },
+    {
+      "type": "tag_single",
+      "label": "Concentrating",
+      "bind": "concentration",
+      "color": "#a078dc"
+    },
+    {
+      "type": "badge_set",
+      "label": "Resources",
+      "bind": "milestones"
+    }
+  ],
+
+  "sheet": {
+    "stat_grid": {
+      "label": "Ability Scores",
+      "bind": "sheet.abilities",
+      "stats": [
+        { "key": "STR", "label": "STR", "show_modifier": true },
+        { "key": "DEX", "label": "DEX", "show_modifier": true },
+        { "key": "CON", "label": "CON", "show_modifier": true },
+        { "key": "INT", "label": "INT", "show_modifier": true },
+        { "key": "WIS", "label": "WIS", "show_modifier": true },
+        { "key": "CHA", "label": "CHA", "show_modifier": true }
+      ]
+    },
+    "sections": [
+      { "type": "attacks",   "label": "Attacks",   "bind": "sheet.attacks" },
+      { "type": "spells",    "label": "Spells",    "bind": "sheet.spells" },
+      { "type": "features",  "label": "Features",  "bind": "sheet.features" },
+      { "type": "inventory", "label": "Inventory", "bind": "sheet.inventory" }
+    ]
+  },
+
+  "vocab": {
+    "conditions": [
+      "Blinded", "Charmed", "Deafened", "Frightened", "Grappled",
+      "Incapacitated", "Invisible", "Paralyzed", "Petrified", "Poisoned",
+      "Prone", "Restrained", "Stunned", "Unconscious", "Exhaustion"
+    ],
+    "sustained_term": "Concentration"
+  }
+}

--- a/templates/state.md
+++ b/templates/state.md
@@ -1,5 +1,5 @@
 # Campaign: <name>
-**Created:** <date>  **Last session:** —  **Session count:** 0  **System Version:** <version>
+**Created:** <date>  **Last session:** —  **Session count:** 0  **System Module:** dnd5e  **System Version:** <version>
 
 ## Current Situation
 - **Location:**


### PR DESCRIPTION
Closes the UI half of #25. Was a docs-only proposal; now it's the working feature.

**What changed:** the character sidebar and sheet render from a per-system `systems/<name>/ui.json` instead of a hardcoded D&D layout. A new system is a ~40-line JSON file, not new front-end code.

- `display/templates/index.html` — manifest-driven widget renderers (`bar`, `stat_lines`, `tag_list`, `tag_single`, `effects`, `badge_set`, `pip_levels`, `feature_flags`, `badge`) + sheet `combat_strip` and `stat_grid`. A built-in default manifest reproduces the original D&D 5e display **exactly**, so an absent/invalid `ui.json` looks identical to before. The attribute grid now supports raw ratings (`show_modifier:false`) for dice-pool systems, not just D&D score+mod.
- `display/gm-display-app.py` — `_load_ui_manifest()` resolves the active campaign's system module → `systems/<module>/ui.json`, injected as `window.GM_UI_MANIFEST`.
- `scripts/paths.py` — `campaign_system()` reads `**System Module:**` from state.md (distinct from the `**System:**` display label), default `dnd5e`.
- `systems/dnd5e/ui.json` — reference manifest (mirrors the built-in default). `systems/UI-MANIFEST.md` — widget catalog + Shadowrun 5e example.

**Backward compatible** — legacy campaigns with no `ui.json` / no system declared render identically; nothing breaks, so by the repo's semver rule this is a MINOR.

**Verification** — JS syntax checked, `dnd5e/ui.json` deep-equals the JS default, resolver unit-tested, and a headless-browser run confirmed all D&D sidebar widgets + the sheet ability grid and combat strip render identically to the prior hardcoded path.

For @eviloverclaude: this is the renderer to build the Shadowrun sheet against — drop a `systems/shadowrun5e/ui.json` (Edge, condition monitors, 8 raw-rating attributes) per the example in UI-MANIFEST.md.