### PR TITLE
chore(display): clear remaining Claude-coupling leftovers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ This project is the LLM-agnostic, system-flexible fork of [claude-dnd-skill](htt
 
 ## [Unreleased]
 
+### Cleared remaining Claude-coupling leftovers
+
+- **`wrapper.py` wraps any agent**, not just Claude — set `GM_AGENT_CMD` (default `claude`) to wrap `opencode`, `gemini`, etc. The PTY wrapper is a legacy/optional path anyway (the canonical setup runs the agent directly + `send.py`).
+- **The phone `/character` route resolves via `paths.py`** (honors `GM_CAMPAIGN_ROOT`) instead of `DND_CAMPAIGN_ROOT` + a hardcoded `~/.claude/dnd` root; the legacy `~/.claude/dnd/characters/` path is kept as a final fallback for older installs.
+- Cosmetic: "the DM (Claude)" → "the GM agent" in a couple of script docstrings.
+
 ## [0.13.0] — 2026-06-27 — System-agnostic character UI + model-agnostic GM hint
 
 ### System-agnostic character UI (systems can define their own sidebar + sheet)

--- a/display/gm-display-app.py
+++ b/display/gm-display-app.py
@@ -55,6 +55,7 @@ from paths import (
     campaign_dir as _campaign_dir,
     find_campaign as _find_campaign,
     campaign_system as _campaign_system,
+    characters_dir as _characters_dir,
 )
 
 # Audio module — degrades silently if numpy not installed
@@ -2176,12 +2177,13 @@ def get_character_sheet(character):
     """Return the markdown content of a PC sheet for the active campaign.
 
     Used by the phone's Character tab. Resolves the active campaign from
-    CAMP_FILE, then reads:
-        <DND_CAMPAIGN_ROOT>/campaigns/<campaign>/characters/<character>.md
+    CAMP_FILE, then reads (via paths.py, which honors GM_CAMPAIGN_ROOT):
+        <root>/campaigns/<campaign>/characters/<character>.md
 
-    Falls back to the global roster at ~/.claude/dnd/characters/<character>.md
-    if the campaign-side file is missing — useful when the character was just
-    imported but not yet replicated.
+    Falls back to the global roster (<root>/characters/<character>.md) if the
+    campaign-side file is missing — useful when the character was just imported
+    but not yet replicated. The legacy ~/.claude/dnd/characters/ path is kept as
+    a final fallback for older Claude-skill installs.
 
     Returns text/markdown so the phone can render in JS without server-side
     dependencies (no `markdown` lib required).
@@ -2203,10 +2205,11 @@ def get_character_sheet(character):
     # here could pivot to arbitrary `<name>.md` reads via os.path.join.
     camp = re.sub(r"[^A-Za-z0-9_-]", "", camp)[:50]
 
-    root = os.environ.get("DND_CAMPAIGN_ROOT", os.path.expanduser("~/.claude/dnd"))
     candidates = []
     if camp:
-        candidates.append(os.path.join(root, "campaigns", camp, "characters", f"{safe}.md"))
+        candidates.append(str(_find_campaign(camp) / "characters" / f"{safe}.md"))
+    candidates.append(str(_characters_dir() / f"{safe}.md"))
+    # Legacy Claude-skill global roster — final fallback for older installs.
     candidates.append(os.path.expanduser(f"~/.claude/dnd/characters/{safe}.md"))
 
     for path in candidates:

--- a/display/wrapper.py
+++ b/display/wrapper.py
@@ -1,17 +1,23 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 """
-wrapper.py — Claude CLI PTY wrapper with secure player-input injection
+wrapper.py — agent CLI PTY wrapper with secure player-input injection
 
 Usage:
-    python3 wrapper.py [claude args...]
+    python3 wrapper.py [agent args...]
 
-Spawns the claude CLI inside a PTY so the terminal experience is identical
-to running `claude` directly. The wrapper's only job beyond pass-through is:
+Spawns the agent CLI inside a PTY so the terminal experience is identical to
+running the agent directly. The agent defaults to `claude`; set GM_AGENT_CMD to
+wrap any code-driven agent (e.g. `opencode`, `gemini`). The wrapper's only job
+beyond pass-through is:
 
   - Poll for `.input_trigger` every 50ms
   - Validate and sanitise the payload
-  - Inject it into Claude's PTY stdin (text + Enter)
+  - Inject it into the agent's PTY stdin (text + Enter)
+
+NOTE: this PTY wrapper is a legacy/optional path. The canonical setup runs the
+agent directly and pushes display content via send.py / push_stats.py (see
+display/README.md) — no wrapper needed.
 
 Display content (narration, stats) is pushed explicitly by the DnD skill
 via send.py / push_stats.py — NOT captured from the raw PTY stream.
@@ -36,6 +42,7 @@ import os
 import pathlib
 import re
 import select
+import shlex
 import signal
 import subprocess
 import sys
@@ -288,11 +295,15 @@ def _sync_winsize(src_fd: int, dst_fd: int) -> None:
 # ─── Entry point ─────────────────────────────────────────────────────────────
 
 def main() -> None:
+    # The agent CLI to wrap. Defaults to `claude` for backward compatibility;
+    # set GM_AGENT_CMD to wrap any code-driven agent (e.g. `opencode`, `gemini`).
+    # Multi-word commands are supported (shlex-split).
+    agent_cmd = shlex.split(os.environ.get("GM_AGENT_CMD", "claude")) or ["claude"]
     argv = sys.argv[1:]
-    if not argv:
-        argv = ["claude"]
-    if argv[0] != "claude":
-        argv = ["claude"] + argv
+    # If the caller didn't name the agent binary themselves, treat their args as
+    # extra args to the configured agent command.
+    if not argv or argv[0] != agent_cmd[0]:
+        argv = agent_cmd + argv
 
     import pty as _pty
     master_fd, slave_fd = _pty.openpty()

--- a/scripts/combat.py
+++ b/scripts/combat.py
@@ -13,7 +13,7 @@ Usage:
     python3 combat.py attack --atk <bonus> --ac <target_ac> --dmg <notation> [--crit]
         Resolves a single attack roll and damage.
 
-Input / Output is JSON-friendly so the DM (Claude) can pipe state between turns.
+Input / Output is JSON-friendly so the GM agent can pipe state between turns.
 
 Example:
     python3 combat.py init '[{"name":"Flerb","dex_mod":0,"hp":12,"ac":16,"type":"pc"},

--- a/systems/dnd5e/character.py
+++ b/systems/dnd5e/character.py
@@ -2,7 +2,7 @@
 """
 character.py — D&D 5e character stat calculator
 
-Derives all secondary stats from raw inputs. Used by the DM (Claude)
+Derives all secondary stats from raw inputs. Used by the GM agent
 to verify and generate character sheets without manual arithmetic.
 
 Usage:


### PR DESCRIPTION
Follow-up to #26/#27 — the Tier 2/3 items from the original audit. None blocked non-Claude use; this just removes the inconsistency.

- **`wrapper.py`** wraps any agent via `GM_AGENT_CMD` (default `claude`) instead of hardcoding the binary. Docstring now notes it's a legacy/optional path (canonical setup runs the agent directly + `send.py`).
- **`/character` route** resolves through `paths.py` (honors `GM_CAMPAIGN_ROOT`) instead of `DND_CAMPAIGN_ROOT` + hardcoded `~/.claude/dnd`; legacy `~/.claude/dnd/characters/` kept as a final fallback for older installs.
- Cosmetic: "the DM (Claude)" → "the GM agent" in two script docstrings.

Backward compatible (default behavior unchanged). All 83 tests pass; path resolution verified to honor `GM_CAMPAIGN_ROOT`.